### PR TITLE
refactor: remove nested subscribes in AdminContainerComponent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ Layered architecture in `backend/src/main/java/com/hrassistant/`:
 - **RxJS**: Do NOT use `takeUntilDestroyed()` on HTTP observables (they auto-complete). Only use it on infinite observables (SSE streams, WebSockets, `interval`, `Subject`, etc.)
 - **Observable naming**: Methods returning `Observable` must be suffixed with `$` (e.g., `getDocuments$()`, `deleteDocument$()`)
 - **No subscribe in services**: Services return Observables, only components subscribe. No nested subscribes — use `switchMap`, `concatMap`, `tap`, `filter` to chain operations
+- **No logic in constructors**: Use `ngOnInit()` for initialization logic (HTTP calls, subscriptions). Only `effect()` stays in constructor (requires injection context)
 
 ## Spring AI Patterns
 

--- a/frontend/src/app/features/admin/components/admin-container/admin-container.component.ts
+++ b/frontend/src/app/features/admin/components/admin-container/admin-container.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CardModule } from 'primeng/card';
 import { ToastModule } from 'primeng/toast';
@@ -39,7 +39,7 @@ import { Document, UploadStatus } from '../../../../core/models';
   styleUrl: './admin-container.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AdminContainerComponent {
+export class AdminContainerComponent implements OnInit {
   private documentService = inject(DocumentService);
   private messageService = inject(MessageService);
 
@@ -69,8 +69,7 @@ export class AdminContainerComponent {
   readonly MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
   readonly ACCEPTED_TYPES = ['application/pdf', 'text/plain'];
 
-  constructor() {
-    // Load documents on init
+  ngOnInit(): void {
     this.loadDocuments$().subscribe();
   }
 

--- a/frontend/src/app/features/admin/components/document-list/document-list.component.ts
+++ b/frontend/src/app/features/admin/components/document-list/document-list.component.ts
@@ -58,7 +58,7 @@ export class DocumentListComponent {
       rejectLabel: 'Annuler',
       acceptButtonStyleClass: 'p-button-danger',
       accept: () => {
-        this.deleteDocument$(document.id);
+        this.deleteDocument(document.id);
       },
     });
   }

--- a/frontend/src/app/features/chat/components/document-selector/document-selector.component.ts
+++ b/frontend/src/app/features/chat/components/document-selector/document-selector.component.ts
@@ -6,6 +6,7 @@ import {
   computed,
   output,
   effect,
+  OnInit,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DocumentService } from '../../../../core/services/document.service';
@@ -25,7 +26,7 @@ import { TooltipModule } from 'primeng/tooltip';
   styleUrl: './document-selector.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DocumentSelectorComponent {
+export class DocumentSelectorComponent implements OnInit {
   private documentService = inject(DocumentService);
 
   // Output event when selection changes
@@ -69,19 +70,19 @@ export class DocumentSelectorComponent {
   });
 
   constructor() {
-    // Effect to auto-select all documents when they load
+    // Effect must stay in constructor (requires injection context)
     effect(() => {
       const indexed = this.indexedDocuments();
       if (indexed.length > 0 && !this.initialSelectionDone()) {
-        // Auto-select all documents on first load
         const allIds = indexed.map((d) => d.id);
         this.selectedIds.set(new Set(allIds));
         this.initialSelectionDone.set(true);
         this.emitSelection();
       }
     });
+  }
 
-    // Load documents if not already loaded
+  ngOnInit(): void {
     if (this.documentService.documents().length === 0) {
       this.documentService.loadDocuments$().subscribe();
     }


### PR DESCRIPTION
## Summary
- Replace nested subscribes with `switchMap`/`tap`/`filter` pipe operators in `executeReplace()` and `saveRename()`
- Refactor `loadDocuments` to return `Observable` instead of subscribing internally
- Add RxJS best practices rules to CLAUDE.md: no subscribe in services, no nested subscribes

## Test plan
- [ ] Verify document rename works correctly
- [ ] Verify document replace (delete + upload) works correctly with progress tracking
- [ ] Verify document list refreshes after all operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)