### PR TITLE
feat: add analytics dashboard

### DIFF
--- a/backend/src/main/java/com/hrassistant/controller/AnalyticsController.java
+++ b/backend/src/main/java/com/hrassistant/controller/AnalyticsController.java
@@ -1,0 +1,26 @@
+package com.hrassistant.controller;
+
+import com.hrassistant.model.analytics.DashboardAnalytics;
+import com.hrassistant.service.AnalyticsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/analytics")
+@RequiredArgsConstructor
+public class AnalyticsController {
+
+  private final AnalyticsService analyticsService;
+
+  @GetMapping("/dashboard")
+  public ResponseEntity<DashboardAnalytics> getDashboardAnalytics() {
+    log.info("Received request for dashboard analytics");
+    DashboardAnalytics analytics = analyticsService.getDashboardAnalytics();
+    return ResponseEntity.ok(analytics);
+  }
+}

--- a/backend/src/main/java/com/hrassistant/model/ChatInteraction.java
+++ b/backend/src/main/java/com/hrassistant/model/ChatInteraction.java
@@ -1,0 +1,60 @@
+package com.hrassistant.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(
+    name = "chat_interactions",
+    indexes = {
+      @Index(name = "idx_chat_interaction_created_at", columnList = "created_at"),
+      @Index(name = "idx_chat_interaction_question", columnList = "question")
+    })
+public class ChatInteraction {
+
+  @Id private String id;
+
+  @NotNull
+  @Size(max = 1000)
+  @Column(nullable = false, length = 1000)
+  private String question;
+
+  @NotNull
+  @Column(name = "response_time_ms", nullable = false)
+  private Long responseTimeMs;
+
+  @ElementCollection
+  @CollectionTable(
+      name = "chat_interaction_documents",
+      joinColumns = @JoinColumn(name = "chat_interaction_id"))
+  @Column(name = "document_id")
+  @Builder.Default
+  private List<String> referencedDocumentIds = new ArrayList<>();
+
+  @NotNull
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @PrePersist
+  public void prePersist() {
+    if (id == null) {
+      id = UUID.randomUUID().toString();
+    }
+    if (createdAt == null) {
+      createdAt = LocalDateTime.now();
+    }
+  }
+}

--- a/backend/src/main/java/com/hrassistant/model/analytics/DailyAverage.java
+++ b/backend/src/main/java/com/hrassistant/model/analytics/DailyAverage.java
@@ -1,0 +1,5 @@
+package com.hrassistant.model.analytics;
+
+import java.time.LocalDate;
+
+public record DailyAverage(LocalDate date, double averageMs) {}

--- a/backend/src/main/java/com/hrassistant/model/analytics/DailyCount.java
+++ b/backend/src/main/java/com/hrassistant/model/analytics/DailyCount.java
@@ -1,0 +1,5 @@
+package com.hrassistant.model.analytics;
+
+import java.time.LocalDate;
+
+public record DailyCount(LocalDate date, long count) {}

--- a/backend/src/main/java/com/hrassistant/model/analytics/DashboardAnalytics.java
+++ b/backend/src/main/java/com/hrassistant/model/analytics/DashboardAnalytics.java
@@ -1,0 +1,13 @@
+package com.hrassistant.model.analytics;
+
+import java.util.List;
+
+public record DashboardAnalytics(
+    long totalQuestionsToday,
+    double averageResponseTimeMs,
+    long totalDocuments,
+    long conversationsThisWeek,
+    List<QuestionFrequency> popularQuestions,
+    List<DocumentReference> topDocuments,
+    List<DailyCount> dailyUsage,
+    List<DailyAverage> dailyResponseTimes) {}

--- a/backend/src/main/java/com/hrassistant/model/analytics/DocumentReference.java
+++ b/backend/src/main/java/com/hrassistant/model/analytics/DocumentReference.java
@@ -1,0 +1,3 @@
+package com.hrassistant.model.analytics;
+
+public record DocumentReference(String documentId, String documentName, long referenceCount) {}

--- a/backend/src/main/java/com/hrassistant/model/analytics/QuestionFrequency.java
+++ b/backend/src/main/java/com/hrassistant/model/analytics/QuestionFrequency.java
@@ -1,0 +1,3 @@
+package com.hrassistant.model.analytics;
+
+public record QuestionFrequency(String question, long count) {}

--- a/backend/src/main/java/com/hrassistant/repository/ChatInteractionRepository.java
+++ b/backend/src/main/java/com/hrassistant/repository/ChatInteractionRepository.java
@@ -1,0 +1,76 @@
+package com.hrassistant.repository;
+
+import com.hrassistant.model.ChatInteraction;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatInteractionRepository extends JpaRepository<ChatInteraction, String> {
+
+  long countByCreatedAtAfter(LocalDateTime after);
+
+  @Query("SELECT COALESCE(AVG(ci.responseTimeMs), 0) FROM ChatInteraction ci")
+  double findAverageResponseTimeMs();
+
+  long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
+  /** Finds the top 10 most frequently asked questions, grouped by lowercase question text. */
+  @Query(
+      value =
+          """
+          SELECT LOWER(ci.question) AS question, COUNT(*) AS cnt
+          FROM chat_interactions ci
+          GROUP BY LOWER(ci.question)
+          ORDER BY cnt DESC
+          LIMIT 10
+          """,
+      nativeQuery = true)
+  List<Object[]> findTopQuestionsByFrequency();
+
+  /** Counts daily interactions for the last 30 days. */
+  @Query(
+      value =
+          """
+          SELECT CAST(ci.created_at AS DATE) AS day, COUNT(*) AS cnt
+          FROM chat_interactions ci
+          WHERE ci.created_at >= :since
+          GROUP BY CAST(ci.created_at AS DATE)
+          ORDER BY day
+          """,
+      nativeQuery = true)
+  List<Object[]> countDailyInteractions(@Param("since") LocalDateTime since);
+
+  /** Finds daily average response times for the last 30 days. */
+  @Query(
+      value =
+          """
+          SELECT CAST(ci.created_at AS DATE) AS day, AVG(ci.response_time_ms) AS avg_ms
+          FROM chat_interactions ci
+          WHERE ci.created_at >= :since
+          GROUP BY CAST(ci.created_at AS DATE)
+          ORDER BY day
+          """,
+      nativeQuery = true)
+  List<Object[]> findDailyAverageResponseTimes(@Param("since") LocalDateTime since);
+
+  /**
+   * Finds top 10 most referenced documents by joining the chat_interaction_documents collection
+   * table with the documents table. Excludes deleted documents.
+   */
+  @Query(
+      value =
+          """
+          SELECT cid.document_id, d.filename, COUNT(*) AS ref_count
+          FROM chat_interaction_documents cid
+          JOIN documents d ON d.id = cid.document_id
+          GROUP BY cid.document_id, d.filename
+          ORDER BY ref_count DESC
+          LIMIT 10
+          """,
+      nativeQuery = true)
+  List<Object[]> findTopReferencedDocuments();
+}

--- a/backend/src/main/java/com/hrassistant/repository/DocumentRepository.java
+++ b/backend/src/main/java/com/hrassistant/repository/DocumentRepository.java
@@ -1,18 +1,18 @@
 package com.hrassistant.repository;
 
 import com.hrassistant.model.Document;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface DocumentRepository extends JpaRepository<Document, String> {
 
-    /**
-     * Retrieves all distinct non-null categories.
-     */
-    @Query("SELECT DISTINCT d.category FROM Document d WHERE d.category IS NOT NULL ORDER BY d.category")
-    List<String> findDistinctCategories();
+  /** Retrieves all distinct non-null categories. */
+  @Query(
+      "SELECT DISTINCT d.category FROM Document d WHERE d.category IS NOT NULL ORDER BY d.category")
+  List<String> findDistinctCategories();
+
+  List<Document> findByFilenameIn(List<String> filenames);
 }

--- a/backend/src/main/java/com/hrassistant/service/AnalyticsService.java
+++ b/backend/src/main/java/com/hrassistant/service/AnalyticsService.java
@@ -1,0 +1,104 @@
+package com.hrassistant.service;
+
+import com.hrassistant.model.analytics.*;
+import com.hrassistant.repository.ChatInteractionRepository;
+import com.hrassistant.repository.DocumentRepository;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AnalyticsService {
+
+  private final ChatInteractionRepository chatInteractionRepository;
+  private final DocumentRepository documentRepository;
+
+  /** Assembles the full dashboard analytics by querying all repository methods. */
+  public DashboardAnalytics getDashboardAnalytics() {
+    log.debug("Building dashboard analytics");
+
+    LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+    LocalDateTime startOfWeek = LocalDate.now().minusDays(7).atStartOfDay();
+    LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+
+    long totalQuestionsToday = chatInteractionRepository.countByCreatedAtAfter(startOfToday);
+    double averageResponseTimeMs = chatInteractionRepository.findAverageResponseTimeMs();
+    long totalDocuments = documentRepository.count();
+    long conversationsThisWeek =
+        chatInteractionRepository.countByCreatedAtBetween(startOfWeek, LocalDateTime.now());
+
+    List<QuestionFrequency> popularQuestions =
+        mapQuestionFrequencies(chatInteractionRepository.findTopQuestionsByFrequency());
+
+    List<DocumentReference> topDocuments =
+        mapDocumentReferences(chatInteractionRepository.findTopReferencedDocuments());
+
+    List<DailyCount> dailyUsage =
+        mapDailyCounts(chatInteractionRepository.countDailyInteractions(thirtyDaysAgo));
+
+    List<DailyAverage> dailyResponseTimes =
+        mapDailyAverages(chatInteractionRepository.findDailyAverageResponseTimes(thirtyDaysAgo));
+
+    log.info(
+        "Dashboard analytics built: {} questions today, {} docs, {} this week",
+        totalQuestionsToday,
+        totalDocuments,
+        conversationsThisWeek);
+
+    return new DashboardAnalytics(
+        totalQuestionsToday,
+        averageResponseTimeMs,
+        totalDocuments,
+        conversationsThisWeek,
+        popularQuestions,
+        topDocuments,
+        dailyUsage,
+        dailyResponseTimes);
+  }
+
+  private List<QuestionFrequency> mapQuestionFrequencies(List<Object[]> rows) {
+    return rows.stream()
+        .map(row -> new QuestionFrequency((String) row[0], ((Number) row[1]).longValue()))
+        .toList();
+  }
+
+  private List<DocumentReference> mapDocumentReferences(List<Object[]> rows) {
+    return rows.stream()
+        .map(
+            row ->
+                new DocumentReference(
+                    (String) row[0], (String) row[1], ((Number) row[2]).longValue()))
+        .toList();
+  }
+
+  private List<DailyCount> mapDailyCounts(List<Object[]> rows) {
+    return rows.stream()
+        .map(row -> new DailyCount(toLocalDate(row[0]), ((Number) row[1]).longValue()))
+        .toList();
+  }
+
+  private List<DailyAverage> mapDailyAverages(List<Object[]> rows) {
+    return rows.stream()
+        .map(row -> new DailyAverage(toLocalDate(row[0]), ((Number) row[1]).doubleValue()))
+        .toList();
+  }
+
+  private LocalDate toLocalDate(Object value) {
+    if (value instanceof Date sqlDate) {
+      return sqlDate.toLocalDate();
+    }
+    if (value instanceof LocalDate ld) {
+      return ld;
+    }
+    if (value instanceof LocalDateTime ldt) {
+      return ldt.toLocalDate();
+    }
+    return LocalDate.parse(value.toString());
+  }
+}

--- a/backend/src/main/java/com/hrassistant/service/CachingStreamingRagService.java
+++ b/backend/src/main/java/com/hrassistant/service/CachingStreamingRagService.java
@@ -1,7 +1,11 @@
 package com.hrassistant.service;
 
 import com.hrassistant.model.CachedResponse;
+import com.hrassistant.model.ChatInteraction;
 import com.hrassistant.model.ChatRequest;
+import com.hrassistant.model.Document;
+import com.hrassistant.repository.ChatInteractionRepository;
+import com.hrassistant.repository.DocumentRepository;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -14,7 +18,8 @@ import reactor.core.scheduler.Schedulers;
 
 /**
  * Decorator service that wraps StreamingRagService with semantic caching. Checks cache before
- * executing RAG pipeline and caches successful responses.
+ * executing RAG pipeline and caches successful responses. Also persists ChatInteraction for
+ * analytics tracking.
  */
 @Slf4j
 @Service
@@ -23,6 +28,8 @@ public class CachingStreamingRagService {
 
   private final StreamingRagService streamingRagService;
   private final CacheService cacheService;
+  private final ChatInteractionRepository chatInteractionRepository;
+  private final DocumentRepository documentRepository;
 
   /**
    * Processes a chat request with semantic caching.
@@ -40,13 +47,15 @@ public class CachingStreamingRagService {
   public Flux<String> chatStream(ChatRequest request) {
     String question = request.getQuestion();
     List<String> documentIds = request.getDocumentIds();
+    long startTime = System.currentTimeMillis();
     log.debug("Processing request with cache check: {} (documentIds={})", question, documentIds);
 
     // Skip cache when document filter is applied
     boolean hasDocumentFilter = documentIds != null && !documentIds.isEmpty();
     if (hasDocumentFilter) {
       log.debug("Document filter applied, bypassing cache");
-      return streamingRagService.chatStream(request);
+      return wrapWithInteractionTracking(
+          streamingRagService.chatStream(request), request, startTime);
     }
 
     // Step 1: Check cache for similar question
@@ -55,12 +64,12 @@ public class CachingStreamingRagService {
     if (cached.isPresent()) {
       // Cache hit - return cached response as stream
       log.info("Serving from cache for question: {}", question);
-      return streamCachedResponse(cached.get());
+      return wrapWithInteractionTracking(streamCachedResponse(cached.get()), request, startTime);
     }
 
     // Cache miss - execute RAG pipeline and cache the result
     log.debug("Cache miss, executing RAG pipeline for question: {}", question);
-    return executeAndCache(request);
+    return executeAndCache(request, startTime);
   }
 
   /**
@@ -90,9 +99,10 @@ public class CachingStreamingRagService {
    * blocking reactor threads.
    *
    * @param request The chat request
+   * @param startTime The start time for response time tracking
    * @return Flux of response tokens
    */
-  private Flux<String> executeAndCache(ChatRequest request) {
+  private Flux<String> executeAndCache(ChatRequest request, long startTime) {
     // Use a buffer to collect tokens for caching without blocking the stream
     List<String> tokensBuffer = new java.util.ArrayList<>();
 
@@ -101,12 +111,12 @@ public class CachingStreamingRagService {
         .doOnNext(tokensBuffer::add) // Add each token to the buffer
         .doOnComplete(
             () -> {
-              // When streaming is complete, cache the full response
+              // When streaming is complete, cache the full response and persist interaction
               String fullResponse = String.join("", tokensBuffer);
               if (StringUtils.hasText(fullResponse)) {
                 List<String> sources = SourceParsingUtil.extractSources(fullResponse);
 
-                // Run caching on a separate thread
+                // Run caching and interaction persistence on a separate thread
                 Schedulers.boundedElastic()
                     .schedule(
                         () -> {
@@ -116,9 +126,57 @@ public class CachingStreamingRagService {
                           } catch (Exception e) {
                             log.warn("Failed to cache response asynchronously: {}", e.getMessage());
                           }
+                          persistInteraction(request, startTime, sources);
                         });
               }
             })
         .doOnError(error -> log.debug("RAG pipeline error, not caching: {}", error.getMessage()));
+  }
+
+  /** Wraps a flux with interaction tracking for cache hits and filtered queries. */
+  private Flux<String> wrapWithInteractionTracking(
+      Flux<String> flux, ChatRequest request, long startTime) {
+    List<String> tokensBuffer = new java.util.ArrayList<>();
+
+    return flux.doOnNext(tokensBuffer::add)
+        .doOnComplete(
+            () -> {
+              String fullResponse = String.join("", tokensBuffer);
+              List<String> sources = SourceParsingUtil.extractSources(fullResponse);
+              Schedulers.boundedElastic()
+                  .schedule(() -> persistInteraction(request, startTime, sources));
+            });
+  }
+
+  /**
+   * Persists a ChatInteraction record for analytics. Resolves document names from sources to
+   * document IDs.
+   */
+  private void persistInteraction(ChatRequest request, long startTime, List<String> sourceNames) {
+    try {
+      long responseTimeMs = System.currentTimeMillis() - startTime;
+
+      List<String> documentIds = List.of();
+      if (sourceNames != null && !sourceNames.isEmpty()) {
+        documentIds =
+            documentRepository.findByFilenameIn(sourceNames).stream().map(Document::getId).toList();
+      }
+
+      ChatInteraction interaction =
+          ChatInteraction.builder()
+              .question(request.getQuestion())
+              .responseTimeMs(responseTimeMs)
+              .referencedDocumentIds(documentIds)
+              .build();
+
+      chatInteractionRepository.save(interaction);
+      log.debug(
+          "Persisted chat interaction: question='{}', responseTimeMs={}, docs={}",
+          request.getQuestion(),
+          responseTimeMs,
+          documentIds.size());
+    } catch (Exception e) {
+      log.warn("Failed to persist chat interaction: {}", e.getMessage());
+    }
   }
 }

--- a/backend/src/test/java/com/hrassistant/controller/AnalyticsControllerTest.java
+++ b/backend/src/test/java/com/hrassistant/controller/AnalyticsControllerTest.java
@@ -1,0 +1,77 @@
+package com.hrassistant.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.hrassistant.model.analytics.*;
+import com.hrassistant.service.AnalyticsService;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsControllerTest {
+
+  @Mock private AnalyticsService analyticsService;
+
+  @InjectMocks private AnalyticsController analyticsController;
+
+  @Test
+  @DisplayName("GET /api/analytics/dashboard returns 200 with correct data")
+  void getDashboardReturns200WithCorrectData() {
+    DashboardAnalytics analytics =
+        new DashboardAnalytics(
+            42L,
+            1500.0,
+            10L,
+            120L,
+            List.of(new QuestionFrequency("leave policy", 15)),
+            List.of(new DocumentReference("doc-1", "handbook.pdf", 25)),
+            List.of(new DailyCount(LocalDate.of(2026, 2, 8), 5)),
+            List.of(new DailyAverage(LocalDate.of(2026, 2, 8), 1200.5)));
+
+    when(analyticsService.getDashboardAnalytics()).thenReturn(analytics);
+
+    ResponseEntity<DashboardAnalytics> response = analyticsController.getDashboardAnalytics();
+
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().totalQuestionsToday()).isEqualTo(42L);
+    assertThat(response.getBody().averageResponseTimeMs()).isEqualTo(1500.0);
+    assertThat(response.getBody().totalDocuments()).isEqualTo(10L);
+    assertThat(response.getBody().conversationsThisWeek()).isEqualTo(120L);
+    assertThat(response.getBody().popularQuestions()).hasSize(1);
+    assertThat(response.getBody().popularQuestions().getFirst().question())
+        .isEqualTo("leave policy");
+    assertThat(response.getBody().topDocuments()).hasSize(1);
+    assertThat(response.getBody().topDocuments().getFirst().documentName())
+        .isEqualTo("handbook.pdf");
+    assertThat(response.getBody().dailyUsage()).hasSize(1);
+    assertThat(response.getBody().dailyResponseTimes()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("GET /api/analytics/dashboard returns empty analytics when no data")
+  void getDashboardReturnsEmptyAnalytics() {
+    DashboardAnalytics emptyAnalytics =
+        new DashboardAnalytics(0L, 0.0, 0L, 0L, List.of(), List.of(), List.of(), List.of());
+
+    when(analyticsService.getDashboardAnalytics()).thenReturn(emptyAnalytics);
+
+    ResponseEntity<DashboardAnalytics> response = analyticsController.getDashboardAnalytics();
+
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().totalQuestionsToday()).isEqualTo(0L);
+    assertThat(response.getBody().popularQuestions()).isEmpty();
+    assertThat(response.getBody().topDocuments()).isEmpty();
+    assertThat(response.getBody().dailyUsage()).isEmpty();
+    assertThat(response.getBody().dailyResponseTimes()).isEmpty();
+  }
+}

--- a/backend/src/test/java/com/hrassistant/service/AnalyticsServiceTest.java
+++ b/backend/src/test/java/com/hrassistant/service/AnalyticsServiceTest.java
@@ -1,0 +1,202 @@
+package com.hrassistant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.hrassistant.model.analytics.*;
+import com.hrassistant.repository.ChatInteractionRepository;
+import com.hrassistant.repository.DocumentRepository;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AnalyticsServiceTest {
+
+  @Mock private ChatInteractionRepository chatInteractionRepository;
+  @Mock private DocumentRepository documentRepository;
+
+  private AnalyticsService analyticsService;
+
+  @BeforeEach
+  void setUp() {
+    analyticsService = new AnalyticsService(chatInteractionRepository, documentRepository);
+  }
+
+  // ========================================================================
+  // getDashboardAnalytics — with data
+  // ========================================================================
+
+  @Nested
+  @DisplayName("getDashboardAnalytics with data")
+  class WithDataTests {
+
+    @Test
+    @DisplayName("Returns correct KPIs when data exists")
+    void returnsCorrectKpis() {
+      when(chatInteractionRepository.countByCreatedAtAfter(any())).thenReturn(42L);
+      when(chatInteractionRepository.findAverageResponseTimeMs()).thenReturn(1500.0);
+      when(documentRepository.count()).thenReturn(10L);
+      when(chatInteractionRepository.countByCreatedAtBetween(any(), any())).thenReturn(120L);
+      when(chatInteractionRepository.findTopQuestionsByFrequency()).thenReturn(List.of());
+      when(chatInteractionRepository.findTopReferencedDocuments()).thenReturn(List.of());
+      when(chatInteractionRepository.countDailyInteractions(any())).thenReturn(List.of());
+      when(chatInteractionRepository.findDailyAverageResponseTimes(any())).thenReturn(List.of());
+
+      DashboardAnalytics result = analyticsService.getDashboardAnalytics();
+
+      assertThat(result.totalQuestionsToday()).isEqualTo(42L);
+      assertThat(result.averageResponseTimeMs()).isEqualTo(1500.0);
+      assertThat(result.totalDocuments()).isEqualTo(10L);
+      assertThat(result.conversationsThisWeek()).isEqualTo(120L);
+    }
+
+    @Test
+    @DisplayName("popularQuestions correctly mapped from repository results")
+    void popularQuestionsMapped() {
+      when(chatInteractionRepository.countByCreatedAtAfter(any())).thenReturn(0L);
+      when(chatInteractionRepository.findAverageResponseTimeMs()).thenReturn(0.0);
+      when(documentRepository.count()).thenReturn(0L);
+      when(chatInteractionRepository.countByCreatedAtBetween(any(), any())).thenReturn(0L);
+      when(chatInteractionRepository.findTopQuestionsByFrequency())
+          .thenReturn(
+              List.of(
+                  new Object[] {"what is the leave policy", 15L},
+                  new Object[] {"how to request time off", 8L}));
+      when(chatInteractionRepository.findTopReferencedDocuments()).thenReturn(List.of());
+      when(chatInteractionRepository.countDailyInteractions(any())).thenReturn(List.of());
+      when(chatInteractionRepository.findDailyAverageResponseTimes(any())).thenReturn(List.of());
+
+      DashboardAnalytics result = analyticsService.getDashboardAnalytics();
+
+      assertThat(result.popularQuestions()).hasSize(2);
+      assertThat(result.popularQuestions().get(0).question()).isEqualTo("what is the leave policy");
+      assertThat(result.popularQuestions().get(0).count()).isEqualTo(15L);
+      assertThat(result.popularQuestions().get(1).question()).isEqualTo("how to request time off");
+      assertThat(result.popularQuestions().get(1).count()).isEqualTo(8L);
+    }
+
+    @Test
+    @DisplayName("topDocuments correctly mapped from repository results")
+    void topDocumentsMapped() {
+      when(chatInteractionRepository.countByCreatedAtAfter(any())).thenReturn(0L);
+      when(chatInteractionRepository.findAverageResponseTimeMs()).thenReturn(0.0);
+      when(documentRepository.count()).thenReturn(0L);
+      when(chatInteractionRepository.countByCreatedAtBetween(any(), any())).thenReturn(0L);
+      when(chatInteractionRepository.findTopQuestionsByFrequency()).thenReturn(List.of());
+      when(chatInteractionRepository.findTopReferencedDocuments())
+          .thenReturn(
+              List.of(
+                  new Object[] {"doc-1", "leave-policy.pdf", 25L},
+                  new Object[] {"doc-2", "handbook.pdf", 12L}));
+      when(chatInteractionRepository.countDailyInteractions(any())).thenReturn(List.of());
+      when(chatInteractionRepository.findDailyAverageResponseTimes(any())).thenReturn(List.of());
+
+      DashboardAnalytics result = analyticsService.getDashboardAnalytics();
+
+      assertThat(result.topDocuments()).hasSize(2);
+      assertThat(result.topDocuments().get(0).documentId()).isEqualTo("doc-1");
+      assertThat(result.topDocuments().get(0).documentName()).isEqualTo("leave-policy.pdf");
+      assertThat(result.topDocuments().get(0).referenceCount()).isEqualTo(25L);
+      assertThat(result.topDocuments().get(1).documentId()).isEqualTo("doc-2");
+      assertThat(result.topDocuments().get(1).documentName()).isEqualTo("handbook.pdf");
+      assertThat(result.topDocuments().get(1).referenceCount()).isEqualTo(12L);
+    }
+
+    @Test
+    @DisplayName("dailyUsage correctly mapped from repository results")
+    void dailyUsageMapped() {
+      LocalDate day1 = LocalDate.of(2026, 2, 8);
+      LocalDate day2 = LocalDate.of(2026, 2, 9);
+
+      when(chatInteractionRepository.countByCreatedAtAfter(any())).thenReturn(0L);
+      when(chatInteractionRepository.findAverageResponseTimeMs()).thenReturn(0.0);
+      when(documentRepository.count()).thenReturn(0L);
+      when(chatInteractionRepository.countByCreatedAtBetween(any(), any())).thenReturn(0L);
+      when(chatInteractionRepository.findTopQuestionsByFrequency()).thenReturn(List.of());
+      when(chatInteractionRepository.findTopReferencedDocuments()).thenReturn(List.of());
+      when(chatInteractionRepository.countDailyInteractions(any()))
+          .thenReturn(
+              List.of(
+                  new Object[] {Date.valueOf(day1), 5L}, new Object[] {Date.valueOf(day2), 12L}));
+      when(chatInteractionRepository.findDailyAverageResponseTimes(any())).thenReturn(List.of());
+
+      DashboardAnalytics result = analyticsService.getDashboardAnalytics();
+
+      assertThat(result.dailyUsage()).hasSize(2);
+      assertThat(result.dailyUsage().get(0).date()).isEqualTo(day1);
+      assertThat(result.dailyUsage().get(0).count()).isEqualTo(5L);
+      assertThat(result.dailyUsage().get(1).date()).isEqualTo(day2);
+      assertThat(result.dailyUsage().get(1).count()).isEqualTo(12L);
+    }
+
+    @Test
+    @DisplayName("dailyResponseTimes correctly mapped from repository results")
+    void dailyResponseTimesMapped() {
+      LocalDate day1 = LocalDate.of(2026, 2, 8);
+      LocalDate day2 = LocalDate.of(2026, 2, 9);
+
+      when(chatInteractionRepository.countByCreatedAtAfter(any())).thenReturn(0L);
+      when(chatInteractionRepository.findAverageResponseTimeMs()).thenReturn(0.0);
+      when(documentRepository.count()).thenReturn(0L);
+      when(chatInteractionRepository.countByCreatedAtBetween(any(), any())).thenReturn(0L);
+      when(chatInteractionRepository.findTopQuestionsByFrequency()).thenReturn(List.of());
+      when(chatInteractionRepository.findTopReferencedDocuments()).thenReturn(List.of());
+      when(chatInteractionRepository.countDailyInteractions(any())).thenReturn(List.of());
+      when(chatInteractionRepository.findDailyAverageResponseTimes(any()))
+          .thenReturn(
+              List.of(
+                  new Object[] {Date.valueOf(day1), 1200.5},
+                  new Object[] {Date.valueOf(day2), 980.3}));
+
+      DashboardAnalytics result = analyticsService.getDashboardAnalytics();
+
+      assertThat(result.dailyResponseTimes()).hasSize(2);
+      assertThat(result.dailyResponseTimes().get(0).date()).isEqualTo(day1);
+      assertThat(result.dailyResponseTimes().get(0).averageMs()).isEqualTo(1200.5);
+      assertThat(result.dailyResponseTimes().get(1).date()).isEqualTo(day2);
+      assertThat(result.dailyResponseTimes().get(1).averageMs()).isEqualTo(980.3);
+    }
+  }
+
+  // ========================================================================
+  // getDashboardAnalytics — no data
+  // ========================================================================
+
+  @Nested
+  @DisplayName("getDashboardAnalytics with no data")
+  class NoDataTests {
+
+    @Test
+    @DisplayName("Returns zeros and empty lists when no data exists")
+    void returnsZerosAndEmptyLists() {
+      when(chatInteractionRepository.countByCreatedAtAfter(any())).thenReturn(0L);
+      when(chatInteractionRepository.findAverageResponseTimeMs()).thenReturn(0.0);
+      when(documentRepository.count()).thenReturn(0L);
+      when(chatInteractionRepository.countByCreatedAtBetween(any(), any())).thenReturn(0L);
+      when(chatInteractionRepository.findTopQuestionsByFrequency()).thenReturn(List.of());
+      when(chatInteractionRepository.findTopReferencedDocuments()).thenReturn(List.of());
+      when(chatInteractionRepository.countDailyInteractions(any())).thenReturn(List.of());
+      when(chatInteractionRepository.findDailyAverageResponseTimes(any())).thenReturn(List.of());
+
+      DashboardAnalytics result = analyticsService.getDashboardAnalytics();
+
+      assertThat(result.totalQuestionsToday()).isZero();
+      assertThat(result.averageResponseTimeMs()).isZero();
+      assertThat(result.totalDocuments()).isZero();
+      assertThat(result.conversationsThisWeek()).isZero();
+      assertThat(result.popularQuestions()).isEmpty();
+      assertThat(result.topDocuments()).isEmpty();
+      assertThat(result.dailyUsage()).isEmpty();
+      assertThat(result.dailyResponseTimes()).isEmpty();
+    }
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/router": "^21.1.0",
         "@primeuix/themes": "^2.0.3",
         "@types/node": "^25.0.9",
+        "chart.js": "^4.5.1",
         "marked": "^17.0.1",
         "ngx-markdown": "^21.0.1",
         "primeicons": "^7.0.0",
@@ -2531,6 +2532,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
       "version": "3.0.5",
@@ -6189,6 +6196,18 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chevrotain": {
       "version": "11.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@angular/router": "^21.1.0",
     "@primeuix/themes": "^2.0.3",
     "@types/node": "^25.0.9",
+    "chart.js": "^4.5.1",
     "marked": "^17.0.1",
     "ngx-markdown": "^21.0.1",
     "primeicons": "^7.0.0",

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -7,24 +7,31 @@ export const routes: Routes = [
   {
     path: '',
     redirectTo: '/chat',
-    pathMatch: 'full'
+    pathMatch: 'full',
   },
   {
     path: 'chat',
     loadComponent: () =>
       import('./features/chat/components/chat-page/chat-page.component').then(
-        m => m.ChatPageComponent
-      )
+        (m) => m.ChatPageComponent,
+      ),
   },
   {
     path: 'admin',
     loadComponent: () =>
       import('./features/admin/components/admin-container/admin-container.component').then(
-        m => m.AdminContainerComponent
-      )
+        (m) => m.AdminContainerComponent,
+      ),
+  },
+  {
+    path: 'analytics',
+    loadComponent: () =>
+      import('./features/analytics/components/analytics-page/analytics-page.component').then(
+        (m) => m.AnalyticsPageComponent,
+      ),
   },
   {
     path: '**',
-    redirectTo: '/chat'
-  }
+    redirectTo: '/chat',
+  },
 ];

--- a/frontend/src/app/core/models/analytics.model.ts
+++ b/frontend/src/app/core/models/analytics.model.ts
@@ -1,0 +1,31 @@
+export interface DashboardAnalytics {
+  totalQuestionsToday: number;
+  averageResponseTimeMs: number;
+  totalDocuments: number;
+  conversationsThisWeek: number;
+  popularQuestions: QuestionFrequency[];
+  topDocuments: DocumentReference[];
+  dailyUsage: DailyCount[];
+  dailyResponseTimes: DailyAverage[];
+}
+
+export interface QuestionFrequency {
+  question: string;
+  count: number;
+}
+
+export interface DocumentReference {
+  documentId: string;
+  documentName: string;
+  referenceCount: number;
+}
+
+export interface DailyCount {
+  date: string;
+  count: number;
+}
+
+export interface DailyAverage {
+  date: string;
+  averageMs: number;
+}

--- a/frontend/src/app/core/models/index.ts
+++ b/frontend/src/app/core/models/index.ts
@@ -12,3 +12,4 @@ export * from './document.model';
 export * from './upload-progress.model';
 export * from './api-error.model';
 export * from './environment.model';
+export * from './analytics.model';

--- a/frontend/src/app/core/services/analytics.service.ts
+++ b/frontend/src/app/core/services/analytics.service.ts
@@ -1,0 +1,17 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { DashboardAnalytics } from '../models';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AnalyticsService {
+  private http = inject(HttpClient);
+  private readonly apiUrl = environment.apiUrl;
+
+  getDashboardAnalytics$(): Observable<DashboardAnalytics> {
+    return this.http.get<DashboardAnalytics>(`${this.apiUrl}/analytics/dashboard`);
+  }
+}

--- a/frontend/src/app/core/services/index.ts
+++ b/frontend/src/app/core/services/index.ts
@@ -7,3 +7,4 @@ export * from './api.service';
 export * from './storage.service';
 export * from './conversation.service';
 export * from './document.service';
+export * from './analytics.service';

--- a/frontend/src/app/features/analytics/components/analytics-page/analytics-page.component.css
+++ b/frontend/src/app/features/analytics/components/analytics-page/analytics-page.component.css
@@ -1,0 +1,150 @@
+/**
+ * Analytics Page - Midnight Studio
+ */
+
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+:host::-webkit-scrollbar {
+  width: 5px;
+}
+
+:host::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+:host::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+}
+
+:host::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.analytics-container {
+  max-width: 1100px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* Page Header */
+.analytics-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.header-content h1 {
+  margin: 0 0 0.375rem 0;
+  font-family: 'Outfit', 'Plus Jakarta Sans', system-ui, sans-serif;
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: var(--midnight-50, #e8eaf0);
+  letter-spacing: -0.03em;
+}
+
+.header-content p {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--midnight-300, #6b7494);
+  line-height: 1.5;
+}
+
+/* Loading State */
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 4rem 2rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(255, 255, 255, 0.08);
+  border-top-color: var(--accent-400, #22d3ee);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-text {
+  font-size: 0.9375rem;
+  color: var(--midnight-300, #6b7494);
+}
+
+/* Error State */
+.error-state {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 12px;
+  color: #f87171;
+  font-size: 0.9375rem;
+}
+
+.error-state svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+/* Lists Section */
+.lists-section {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .analytics-container {
+    padding: 1.5rem 1rem;
+    gap: 1.5rem;
+  }
+
+  .header-content h1 {
+    font-size: 1.5rem;
+  }
+
+  .lists-section {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .analytics-container {
+    padding: 1rem 0.75rem;
+  }
+
+  .header-content h1 {
+    font-size: 1.375rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-spinner {
+    animation: none;
+  }
+}

--- a/frontend/src/app/features/analytics/components/analytics-page/analytics-page.component.html
+++ b/frontend/src/app/features/analytics/components/analytics-page/analytics-page.component.html
@@ -1,0 +1,54 @@
+<div class="analytics-container">
+  <!-- Header -->
+  <div class="analytics-header">
+    <div class="header-content">
+      <h1>Analytics</h1>
+      <p>Monitor usage, performance, and trends for your HR Assistant</p>
+    </div>
+  </div>
+
+  <!-- Loading State -->
+  @if (loading()) {
+    <div class="loading-state">
+      <div class="loading-spinner"></div>
+      <span class="loading-text">Loading analytics...</span>
+    </div>
+  }
+
+  <!-- Error State -->
+  @if (error()) {
+    <div class="error-state">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+        <path
+          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <span>{{ error() }}</span>
+    </div>
+  }
+
+  <!-- Dashboard Content -->
+  @if (analytics(); as data) {
+    <!-- KPI Cards -->
+    <app-kpi-cards
+      [totalQuestionsToday]="data.totalQuestionsToday"
+      [averageResponseTimeMs]="data.averageResponseTimeMs"
+      [totalDocuments]="data.totalDocuments"
+      [conversationsThisWeek]="data.conversationsThisWeek"
+    />
+
+    <!-- Lists Section -->
+    <div class="lists-section">
+      <app-popular-questions [questions]="data.popularQuestions" />
+      <app-top-documents [documents]="data.topDocuments" />
+    </div>
+
+    <!-- Charts Section -->
+    <app-usage-chart
+      [dailyUsage]="data.dailyUsage"
+      [dailyResponseTimes]="data.dailyResponseTimes"
+    />
+  }
+</div>

--- a/frontend/src/app/features/analytics/components/analytics-page/analytics-page.component.spec.ts
+++ b/frontend/src/app/features/analytics/components/analytics-page/analytics-page.component.spec.ts
@@ -1,0 +1,173 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { AnalyticsPageComponent } from './analytics-page.component';
+import { AnalyticsService } from '../../../../core/services/analytics.service';
+import { DashboardAnalytics } from '../../../../core/models';
+import { of, throwError } from 'rxjs';
+import { vi } from 'vitest';
+
+const mockAnalytics: DashboardAnalytics = {
+  totalQuestionsToday: 42,
+  averageResponseTimeMs: 1500,
+  totalDocuments: 10,
+  conversationsThisWeek: 120,
+  popularQuestions: [
+    { question: 'What is the leave policy?', count: 15 },
+    { question: 'How to request time off?', count: 8 },
+  ],
+  topDocuments: [{ documentId: 'doc-1', documentName: 'handbook.pdf', referenceCount: 25 }],
+  dailyUsage: [{ date: '2026-02-08', count: 5 }],
+  dailyResponseTimes: [{ date: '2026-02-08', averageMs: 1200.5 }],
+};
+
+describe('AnalyticsPageComponent', () => {
+  let component: AnalyticsPageComponent;
+  let fixture: ComponentFixture<AnalyticsPageComponent>;
+  let analyticsServiceMock: { getDashboardAnalytics$: ReturnType<typeof vi.fn> };
+
+  function createComponent() {
+    fixture = TestBed.createComponent(AnalyticsPageComponent);
+    component = fixture.componentInstance;
+  }
+
+  describe('with data', () => {
+    beforeEach(async () => {
+      analyticsServiceMock = {
+        getDashboardAnalytics$: vi.fn().mockReturnValue(of(mockAnalytics)),
+      };
+
+      await TestBed.configureTestingModule({
+        imports: [AnalyticsPageComponent],
+        providers: [
+          { provide: AnalyticsService, useValue: analyticsServiceMock },
+          provideRouter([]),
+          provideHttpClient(),
+          provideHttpClientTesting(),
+        ],
+      }).compileComponents();
+
+      createComponent();
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should set loading to false after data loads', () => {
+      expect(component.loading()).toBe(false);
+    });
+
+    it('should set analytics data', () => {
+      expect(component.analytics()).toEqual(mockAnalytics);
+    });
+
+    it('should not have error', () => {
+      expect(component.error()).toBeNull();
+    });
+
+    it('should render kpi-cards component', () => {
+      const kpiCards = fixture.nativeElement.querySelector('app-kpi-cards');
+      expect(kpiCards).toBeTruthy();
+    });
+
+    it('should render popular-questions component', () => {
+      const popularQuestions = fixture.nativeElement.querySelector('app-popular-questions');
+      expect(popularQuestions).toBeTruthy();
+    });
+
+    it('should render top-documents component', () => {
+      const topDocuments = fixture.nativeElement.querySelector('app-top-documents');
+      expect(topDocuments).toBeTruthy();
+    });
+
+    it('should render usage-chart component', () => {
+      const usageChart = fixture.nativeElement.querySelector('app-usage-chart');
+      expect(usageChart).toBeTruthy();
+    });
+
+    it('should not show loading spinner', () => {
+      const loadingState = fixture.nativeElement.querySelector('.loading-state');
+      expect(loadingState).toBeFalsy();
+    });
+
+    it('should not show error state', () => {
+      const errorState = fixture.nativeElement.querySelector('.error-state');
+      expect(errorState).toBeFalsy();
+    });
+  });
+
+  describe('loading state', () => {
+    beforeEach(async () => {
+      // Never-completing observable to keep loading state
+      analyticsServiceMock = {
+        getDashboardAnalytics$: vi.fn().mockReturnValue(new (await import('rxjs')).Subject()),
+      };
+
+      await TestBed.configureTestingModule({
+        imports: [AnalyticsPageComponent],
+        providers: [
+          { provide: AnalyticsService, useValue: analyticsServiceMock },
+          provideRouter([]),
+          provideHttpClient(),
+          provideHttpClientTesting(),
+        ],
+      }).compileComponents();
+
+      createComponent();
+      fixture.detectChanges();
+    });
+
+    it('should show loading state initially', () => {
+      expect(component.loading()).toBe(true);
+    });
+
+    it('should display loading spinner', () => {
+      const loadingState = fixture.nativeElement.querySelector('.loading-state');
+      expect(loadingState).toBeTruthy();
+    });
+  });
+
+  describe('error state', () => {
+    beforeEach(async () => {
+      analyticsServiceMock = {
+        getDashboardAnalytics$: vi
+          .fn()
+          .mockReturnValue(throwError(() => new Error('Server error'))),
+      };
+
+      await TestBed.configureTestingModule({
+        imports: [AnalyticsPageComponent],
+        providers: [
+          { provide: AnalyticsService, useValue: analyticsServiceMock },
+          provideRouter([]),
+          provideHttpClient(),
+          provideHttpClientTesting(),
+        ],
+      }).compileComponents();
+
+      createComponent();
+      fixture.detectChanges();
+    });
+
+    it('should set loading to false on error', () => {
+      expect(component.loading()).toBe(false);
+    });
+
+    it('should set error message', () => {
+      expect(component.error()).toBe('Failed to load analytics data');
+    });
+
+    it('should display error state', () => {
+      const errorState = fixture.nativeElement.querySelector('.error-state');
+      expect(errorState).toBeTruthy();
+    });
+
+    it('should not render dashboard components', () => {
+      const kpiCards = fixture.nativeElement.querySelector('app-kpi-cards');
+      expect(kpiCards).toBeFalsy();
+    });
+  });
+});

--- a/frontend/src/app/features/analytics/components/analytics-page/analytics-page.component.ts
+++ b/frontend/src/app/features/analytics/components/analytics-page/analytics-page.component.ts
@@ -1,0 +1,41 @@
+import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { AnalyticsService } from '../../../../core/services/analytics.service';
+import { DashboardAnalytics } from '../../../../core/models';
+import { KpiCardsComponent } from '../kpi-cards/kpi-cards.component';
+import { PopularQuestionsComponent } from '../popular-questions/popular-questions.component';
+import { TopDocumentsComponent } from '../top-documents/top-documents.component';
+import { UsageChartComponent } from '../usage-chart/usage-chart.component';
+
+@Component({
+  selector: 'app-analytics-page',
+  imports: [
+    KpiCardsComponent,
+    PopularQuestionsComponent,
+    TopDocumentsComponent,
+    UsageChartComponent,
+  ],
+  templateUrl: './analytics-page.component.html',
+  styleUrl: './analytics-page.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AnalyticsPageComponent implements OnInit {
+  private analyticsService = inject(AnalyticsService);
+
+  analytics = signal<DashboardAnalytics | null>(null);
+  loading = signal(true);
+  error = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.analyticsService.getDashboardAnalytics$().subscribe({
+      next: (data) => {
+        this.analytics.set(data);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.error.set('Failed to load analytics data');
+        this.loading.set(false);
+        console.error('Error loading analytics:', err);
+      },
+    });
+  }
+}

--- a/frontend/src/app/features/analytics/components/kpi-cards/kpi-cards.component.css
+++ b/frontend/src/app/features/analytics/components/kpi-cards/kpi-cards.component.css
@@ -1,0 +1,93 @@
+/**
+ * KPI Cards - Midnight Studio
+ */
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+}
+
+.kpi-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.25rem;
+  background: var(--midnight-900, #0f1629);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 16px;
+  transition: border-color 0.2s ease;
+}
+
+.kpi-card:hover {
+  border-color: rgba(6, 182, 212, 0.2);
+}
+
+.kpi-icon {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(6, 182, 212, 0.12);
+  border-radius: 12px;
+}
+
+.kpi-icon svg {
+  width: 22px;
+  height: 22px;
+  stroke: var(--accent-400, #22d3ee);
+}
+
+.kpi-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.kpi-value {
+  font-family: 'Outfit', system-ui, sans-serif;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--midnight-50, #e8eaf0);
+  line-height: 1.2;
+}
+
+.kpi-label {
+  font-size: 0.75rem;
+  color: var(--midnight-300, #6b7494);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+  .kpi-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .kpi-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .kpi-card {
+    padding: 1rem;
+  }
+
+  .kpi-value {
+    font-size: 1.25rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kpi-card {
+    transition: none;
+  }
+}

--- a/frontend/src/app/features/analytics/components/kpi-cards/kpi-cards.component.html
+++ b/frontend/src/app/features/analytics/components/kpi-cards/kpi-cards.component.html
@@ -1,0 +1,69 @@
+<div class="kpi-grid">
+  <!-- Questions Today -->
+  <div class="kpi-card">
+    <div class="kpi-icon">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+        <path
+          d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </div>
+    <div class="kpi-content">
+      <span class="kpi-value">{{ totalQuestionsToday() }}</span>
+      <span class="kpi-label">Questions Today</span>
+    </div>
+  </div>
+
+  <!-- Average Response Time -->
+  <div class="kpi-card">
+    <div class="kpi-icon">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+        <path
+          d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </div>
+    <div class="kpi-content">
+      <span class="kpi-value">{{ formattedResponseTime() }}</span>
+      <span class="kpi-label">Avg Response Time</span>
+    </div>
+  </div>
+
+  <!-- Total Documents -->
+  <div class="kpi-card">
+    <div class="kpi-icon">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+        <path
+          d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </div>
+    <div class="kpi-content">
+      <span class="kpi-value">{{ totalDocuments() }}</span>
+      <span class="kpi-label">Total Documents</span>
+    </div>
+  </div>
+
+  <!-- Conversations This Week -->
+  <div class="kpi-card">
+    <div class="kpi-icon">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+        <path
+          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </div>
+    <div class="kpi-content">
+      <span class="kpi-value">{{ conversationsThisWeek() }}</span>
+      <span class="kpi-label">Conversations This Week</span>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/analytics/components/kpi-cards/kpi-cards.component.spec.ts
+++ b/frontend/src/app/features/analytics/components/kpi-cards/kpi-cards.component.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { KpiCardsComponent } from './kpi-cards.component';
+
+@Component({
+  imports: [KpiCardsComponent],
+  template: `
+    <app-kpi-cards
+      [totalQuestionsToday]="totalQuestionsToday"
+      [averageResponseTimeMs]="averageResponseTimeMs"
+      [totalDocuments]="totalDocuments"
+      [conversationsThisWeek]="conversationsThisWeek"
+    />
+  `,
+})
+class TestHostComponent {
+  totalQuestionsToday = 42;
+  averageResponseTimeMs = 1500;
+  totalDocuments = 10;
+  conversationsThisWeek = 120;
+}
+
+describe('KpiCardsComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    hostFixture.detectChanges();
+  });
+
+  it('should create', () => {
+    const kpiCards = hostFixture.nativeElement.querySelector('app-kpi-cards');
+    expect(kpiCards).toBeTruthy();
+  });
+
+  it('should display total questions today', () => {
+    const values = hostFixture.nativeElement.querySelectorAll('.kpi-value');
+    expect(values[0].textContent.trim()).toBe('42');
+  });
+
+  it('should display formatted response time in seconds', () => {
+    const values = hostFixture.nativeElement.querySelectorAll('.kpi-value');
+    expect(values[1].textContent.trim()).toBe('1.5s');
+  });
+
+  it('should display total documents', () => {
+    const values = hostFixture.nativeElement.querySelectorAll('.kpi-value');
+    expect(values[2].textContent.trim()).toBe('10');
+  });
+
+  it('should display conversations this week', () => {
+    const values = hostFixture.nativeElement.querySelectorAll('.kpi-value');
+    expect(values[3].textContent.trim()).toBe('120');
+  });
+
+  it('should format zero response time as 0s', () => {
+    const zeroFixture = TestBed.createComponent(TestHostComponent);
+    zeroFixture.componentInstance.averageResponseTimeMs = 0;
+    zeroFixture.detectChanges();
+
+    const values = zeroFixture.nativeElement.querySelectorAll('.kpi-value');
+    expect(values[1].textContent.trim()).toBe('0s');
+  });
+
+  it('should format large response time', () => {
+    const largeFixture = TestBed.createComponent(TestHostComponent);
+    largeFixture.componentInstance.averageResponseTimeMs = 12345;
+    largeFixture.detectChanges();
+
+    const values = largeFixture.nativeElement.querySelectorAll('.kpi-value');
+    expect(values[1].textContent.trim()).toBe('12.3s');
+  });
+
+  it('should render four kpi cards', () => {
+    const cards = hostFixture.nativeElement.querySelectorAll('.kpi-card');
+    expect(cards.length).toBe(4);
+  });
+
+  it('should display correct labels', () => {
+    const labels = hostFixture.nativeElement.querySelectorAll('.kpi-label');
+    expect(labels[0].textContent.trim()).toBe('Questions Today');
+    expect(labels[1].textContent.trim()).toBe('Avg Response Time');
+    expect(labels[2].textContent.trim()).toBe('Total Documents');
+    expect(labels[3].textContent.trim()).toBe('Conversations This Week');
+  });
+});

--- a/frontend/src/app/features/analytics/components/kpi-cards/kpi-cards.component.ts
+++ b/frontend/src/app/features/analytics/components/kpi-cards/kpi-cards.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+@Component({
+  selector: 'app-kpi-cards',
+  imports: [],
+  templateUrl: './kpi-cards.component.html',
+  styleUrl: './kpi-cards.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KpiCardsComponent {
+  totalQuestionsToday = input.required<number>();
+  averageResponseTimeMs = input.required<number>();
+  totalDocuments = input.required<number>();
+  conversationsThisWeek = input.required<number>();
+
+  formattedResponseTime = computed(() => {
+    const ms = this.averageResponseTimeMs();
+    if (ms === 0) return '0s';
+    return (ms / 1000).toFixed(1) + 's';
+  });
+}

--- a/frontend/src/app/features/analytics/components/popular-questions/popular-questions.component.css
+++ b/frontend/src/app/features/analytics/components/popular-questions/popular-questions.component.css
@@ -1,0 +1,101 @@
+/**
+ * Popular Questions - Midnight Studio
+ */
+
+.panel {
+  background: var(--midnight-900, #0f1629);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.panel-header svg {
+  width: 18px;
+  height: 18px;
+  stroke: var(--accent-400, #22d3ee);
+  flex-shrink: 0;
+}
+
+.panel-header h3 {
+  margin: 0;
+  font-family: 'Outfit', 'Plus Jakarta Sans', system-ui, sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--midnight-50, #e8eaf0);
+}
+
+/* Empty State */
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1.25rem;
+  color: var(--midnight-400, #4a5578);
+  font-size: 0.875rem;
+}
+
+/* Question List */
+.question-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.question-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  transition: background 0.15s ease;
+}
+
+.question-item:last-child {
+  border-bottom: none;
+}
+
+.question-item:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.rank {
+  flex-shrink: 0;
+  font-family: 'Outfit', system-ui, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--accent-400, #22d3ee);
+  min-width: 28px;
+}
+
+.question-text {
+  flex: 1;
+  font-size: 0.875rem;
+  color: var(--midnight-100, #c4c9d8);
+  line-height: 1.4;
+  min-width: 0;
+}
+
+.count-badge {
+  flex-shrink: 0;
+  padding: 0.1875rem 0.5rem;
+  font-family: 'Outfit', system-ui, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-400, #22d3ee);
+  background: rgba(6, 182, 212, 0.12);
+  border-radius: 6px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .question-item {
+    transition: none;
+  }
+}

--- a/frontend/src/app/features/analytics/components/popular-questions/popular-questions.component.html
+++ b/frontend/src/app/features/analytics/components/popular-questions/popular-questions.component.html
@@ -1,0 +1,33 @@
+<div class="panel">
+  <div class="panel-header">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+      <path
+        d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    <h3>Popular Questions</h3>
+  </div>
+
+  @if (questions().length === 0) {
+    <div class="empty-state">
+      <span>No questions recorded yet</span>
+    </div>
+  } @else {
+    <ul class="question-list">
+      @for (q of questions(); track q.question; let i = $index) {
+        <li class="question-item">
+          <span class="rank">#{{ i + 1 }}</span>
+          <span
+            class="question-text"
+            [pTooltip]="needsTruncation(q.question) ? q.question : ''"
+            tooltipPosition="top"
+            >{{ truncate(q.question) }}</span
+          >
+          <span class="count-badge">{{ q.count }}</span>
+        </li>
+      }
+    </ul>
+  }
+</div>

--- a/frontend/src/app/features/analytics/components/popular-questions/popular-questions.component.spec.ts
+++ b/frontend/src/app/features/analytics/components/popular-questions/popular-questions.component.spec.ts
@@ -1,0 +1,101 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { PopularQuestionsComponent } from './popular-questions.component';
+import { QuestionFrequency } from '../../../../core/models';
+
+@Component({
+  imports: [PopularQuestionsComponent],
+  template: `<app-popular-questions [questions]="questions" />`,
+})
+class TestHostComponent {
+  questions: QuestionFrequency[] = [];
+}
+
+describe('PopularQuestionsComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+  });
+
+  it('should create', () => {
+    hostFixture.detectChanges();
+    const el = hostFixture.nativeElement.querySelector('app-popular-questions');
+    expect(el).toBeTruthy();
+  });
+
+  it('should show empty state when no questions', () => {
+    hostComponent.questions = [];
+    hostFixture.detectChanges();
+
+    const emptyState = hostFixture.nativeElement.querySelector('.empty-state');
+    expect(emptyState).toBeTruthy();
+    expect(emptyState.textContent).toContain('No questions recorded yet');
+  });
+
+  it('should render question list when questions exist', () => {
+    hostComponent.questions = [
+      { question: 'What is the leave policy?', count: 15 },
+      { question: 'How to request time off?', count: 8 },
+    ];
+    hostFixture.detectChanges();
+
+    const items = hostFixture.nativeElement.querySelectorAll('.question-item');
+    expect(items.length).toBe(2);
+  });
+
+  it('should display question text and count', () => {
+    hostComponent.questions = [{ question: 'What is the leave policy?', count: 15 }];
+    hostFixture.detectChanges();
+
+    const questionText = hostFixture.nativeElement.querySelector('.question-text');
+    const countBadge = hostFixture.nativeElement.querySelector('.count-badge');
+    expect(questionText.textContent).toContain('What is the leave policy?');
+    expect(countBadge.textContent.trim()).toBe('15');
+  });
+
+  it('should display rank numbers', () => {
+    hostComponent.questions = [
+      { question: 'Q1', count: 10 },
+      { question: 'Q2', count: 5 },
+    ];
+    hostFixture.detectChanges();
+
+    const ranks = hostFixture.nativeElement.querySelectorAll('.rank');
+    expect(ranks[0].textContent.trim()).toBe('#1');
+    expect(ranks[1].textContent.trim()).toBe('#2');
+  });
+
+  it('should truncate long questions', () => {
+    const longQuestion = 'A'.repeat(150);
+    hostComponent.questions = [{ question: longQuestion, count: 5 }];
+    hostFixture.detectChanges();
+
+    const questionText = hostFixture.nativeElement.querySelector('.question-text');
+    expect(questionText.textContent).toContain('...');
+    expect(questionText.textContent.length).toBeLessThan(150);
+  });
+
+  it('should not truncate short questions', () => {
+    hostComponent.questions = [{ question: 'Short question', count: 5 }];
+    hostFixture.detectChanges();
+
+    const questionText = hostFixture.nativeElement.querySelector('.question-text');
+    expect(questionText.textContent).toContain('Short question');
+    expect(questionText.textContent).not.toContain('...');
+  });
+
+  it('should not show empty state when questions exist', () => {
+    hostComponent.questions = [{ question: 'Q1', count: 10 }];
+    hostFixture.detectChanges();
+
+    const emptyState = hostFixture.nativeElement.querySelector('.empty-state');
+    expect(emptyState).toBeFalsy();
+  });
+});

--- a/frontend/src/app/features/analytics/components/popular-questions/popular-questions.component.ts
+++ b/frontend/src/app/features/analytics/components/popular-questions/popular-questions.component.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { TooltipModule } from 'primeng/tooltip';
+import { QuestionFrequency } from '../../../../core/models';
+
+@Component({
+  selector: 'app-popular-questions',
+  imports: [TooltipModule],
+  templateUrl: './popular-questions.component.html',
+  styleUrl: './popular-questions.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PopularQuestionsComponent {
+  questions = input.required<QuestionFrequency[]>();
+
+  truncate(text: string, maxLength = 100): string {
+    if (text.length <= maxLength) return text;
+    return text.substring(0, maxLength) + '...';
+  }
+
+  needsTruncation(text: string, maxLength = 100): boolean {
+    return text.length > maxLength;
+  }
+}

--- a/frontend/src/app/features/analytics/components/top-documents/top-documents.component.css
+++ b/frontend/src/app/features/analytics/components/top-documents/top-documents.component.css
@@ -1,0 +1,104 @@
+/**
+ * Top Documents - Midnight Studio
+ */
+
+.panel {
+  background: var(--midnight-900, #0f1629);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.panel-header svg {
+  width: 18px;
+  height: 18px;
+  stroke: var(--accent-400, #22d3ee);
+  flex-shrink: 0;
+}
+
+.panel-header h3 {
+  margin: 0;
+  font-family: 'Outfit', 'Plus Jakarta Sans', system-ui, sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--midnight-50, #e8eaf0);
+}
+
+/* Empty State */
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1.25rem;
+  color: var(--midnight-400, #4a5578);
+  font-size: 0.875rem;
+}
+
+/* Document List */
+.document-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.document-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  transition: background 0.15s ease;
+}
+
+.document-item:last-child {
+  border-bottom: none;
+}
+
+.document-item:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.rank {
+  flex-shrink: 0;
+  font-family: 'Outfit', system-ui, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--accent-400, #22d3ee);
+  min-width: 28px;
+}
+
+.document-name {
+  flex: 1;
+  font-size: 0.875rem;
+  color: var(--midnight-100, #c4c9d8);
+  line-height: 1.4;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.count-badge {
+  flex-shrink: 0;
+  padding: 0.1875rem 0.5rem;
+  font-family: 'Outfit', system-ui, sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-400, #22d3ee);
+  background: rgba(6, 182, 212, 0.12);
+  border-radius: 6px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .document-item {
+    transition: none;
+  }
+}

--- a/frontend/src/app/features/analytics/components/top-documents/top-documents.component.html
+++ b/frontend/src/app/features/analytics/components/top-documents/top-documents.component.html
@@ -1,0 +1,28 @@
+<div class="panel">
+  <div class="panel-header">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+      <path
+        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+    <h3>Top Documents</h3>
+  </div>
+
+  @if (documents().length === 0) {
+    <div class="empty-state">
+      <span>No document references recorded yet</span>
+    </div>
+  } @else {
+    <ul class="document-list">
+      @for (doc of documents(); track doc.documentId; let i = $index) {
+        <li class="document-item">
+          <span class="rank">#{{ i + 1 }}</span>
+          <span class="document-name">{{ doc.documentName }}</span>
+          <span class="count-badge">{{ doc.referenceCount }}</span>
+        </li>
+      }
+    </ul>
+  }
+</div>

--- a/frontend/src/app/features/analytics/components/top-documents/top-documents.component.spec.ts
+++ b/frontend/src/app/features/analytics/components/top-documents/top-documents.component.spec.ts
@@ -1,0 +1,86 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { TopDocumentsComponent } from './top-documents.component';
+import { DocumentReference } from '../../../../core/models';
+
+@Component({
+  imports: [TopDocumentsComponent],
+  template: `<app-top-documents [documents]="documents" />`,
+})
+class TestHostComponent {
+  documents: DocumentReference[] = [];
+}
+
+describe('TopDocumentsComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+  });
+
+  it('should create', () => {
+    hostFixture.detectChanges();
+    const el = hostFixture.nativeElement.querySelector('app-top-documents');
+    expect(el).toBeTruthy();
+  });
+
+  it('should show empty state when no documents', () => {
+    hostComponent.documents = [];
+    hostFixture.detectChanges();
+
+    const emptyState = hostFixture.nativeElement.querySelector('.empty-state');
+    expect(emptyState).toBeTruthy();
+    expect(emptyState.textContent).toContain('No document references recorded yet');
+  });
+
+  it('should render document list when documents exist', () => {
+    hostComponent.documents = [
+      { documentId: 'doc-1', documentName: 'handbook.pdf', referenceCount: 25 },
+      { documentId: 'doc-2', documentName: 'leave-policy.pdf', referenceCount: 12 },
+    ];
+    hostFixture.detectChanges();
+
+    const items = hostFixture.nativeElement.querySelectorAll('.document-item');
+    expect(items.length).toBe(2);
+  });
+
+  it('should display document name and reference count', () => {
+    hostComponent.documents = [
+      { documentId: 'doc-1', documentName: 'handbook.pdf', referenceCount: 25 },
+    ];
+    hostFixture.detectChanges();
+
+    const docName = hostFixture.nativeElement.querySelector('.document-name');
+    const countBadge = hostFixture.nativeElement.querySelector('.count-badge');
+    expect(docName.textContent).toContain('handbook.pdf');
+    expect(countBadge.textContent.trim()).toBe('25');
+  });
+
+  it('should display rank numbers', () => {
+    hostComponent.documents = [
+      { documentId: 'doc-1', documentName: 'handbook.pdf', referenceCount: 25 },
+      { documentId: 'doc-2', documentName: 'leave-policy.pdf', referenceCount: 12 },
+    ];
+    hostFixture.detectChanges();
+
+    const ranks = hostFixture.nativeElement.querySelectorAll('.rank');
+    expect(ranks[0].textContent.trim()).toBe('#1');
+    expect(ranks[1].textContent.trim()).toBe('#2');
+  });
+
+  it('should not show empty state when documents exist', () => {
+    hostComponent.documents = [
+      { documentId: 'doc-1', documentName: 'handbook.pdf', referenceCount: 25 },
+    ];
+    hostFixture.detectChanges();
+
+    const emptyState = hostFixture.nativeElement.querySelector('.empty-state');
+    expect(emptyState).toBeFalsy();
+  });
+});

--- a/frontend/src/app/features/analytics/components/top-documents/top-documents.component.ts
+++ b/frontend/src/app/features/analytics/components/top-documents/top-documents.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { DocumentReference } from '../../../../core/models';
+
+@Component({
+  selector: 'app-top-documents',
+  imports: [],
+  templateUrl: './top-documents.component.html',
+  styleUrl: './top-documents.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TopDocumentsComponent {
+  documents = input.required<DocumentReference[]>();
+}

--- a/frontend/src/app/features/analytics/components/usage-chart/usage-chart.component.css
+++ b/frontend/src/app/features/analytics/components/usage-chart/usage-chart.component.css
@@ -1,0 +1,51 @@
+/**
+ * Usage Chart - Midnight Studio
+ */
+
+.charts-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+.chart-panel {
+  background: var(--midnight-900, #0f1629);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.chart-header {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.chart-header svg {
+  width: 18px;
+  height: 18px;
+  stroke: var(--accent-400, #22d3ee);
+  flex-shrink: 0;
+}
+
+.chart-header h3 {
+  margin: 0;
+  font-family: 'Outfit', 'Plus Jakarta Sans', system-ui, sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--midnight-50, #e8eaf0);
+}
+
+.chart-body {
+  padding: 1.25rem;
+  height: 280px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .charts-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/app/features/analytics/components/usage-chart/usage-chart.component.html
+++ b/frontend/src/app/features/analytics/components/usage-chart/usage-chart.component.html
@@ -1,0 +1,31 @@
+<div class="charts-grid">
+  <!-- Daily Usage Bar Chart -->
+  <div class="chart-panel">
+    <div class="chart-header">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+        <path
+          d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <h3>Daily Usage</h3>
+    </div>
+    <div class="chart-body">
+      <p-chart type="bar" [data]="usageChartData()" [options]="usageChartOptions" />
+    </div>
+  </div>
+
+  <!-- Response Time Line Chart -->
+  <div class="chart-panel">
+    <div class="chart-header">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+        <path d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+      <h3>Response Time Trend</h3>
+    </div>
+    <div class="chart-body">
+      <p-chart type="line" [data]="responseTimeChartData()" [options]="responseTimeChartOptions" />
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/features/analytics/components/usage-chart/usage-chart.component.spec.ts
+++ b/frontend/src/app/features/analytics/components/usage-chart/usage-chart.component.spec.ts
@@ -1,0 +1,106 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { UsageChartComponent } from './usage-chart.component';
+import { DailyCount, DailyAverage } from '../../../../core/models';
+
+@Component({
+  imports: [UsageChartComponent],
+  template: `
+    <app-usage-chart [dailyUsage]="dailyUsage" [dailyResponseTimes]="dailyResponseTimes" />
+  `,
+})
+class TestHostComponent {
+  dailyUsage: DailyCount[] = [];
+  dailyResponseTimes: DailyAverage[] = [];
+}
+
+describe('UsageChartComponent', () => {
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let hostComponent: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+  });
+
+  it('should create', () => {
+    hostFixture.detectChanges();
+    const el = hostFixture.nativeElement.querySelector('app-usage-chart');
+    expect(el).toBeTruthy();
+  });
+
+  it('should render two chart panels', () => {
+    hostFixture.detectChanges();
+    const panels = hostFixture.nativeElement.querySelectorAll('.chart-panel');
+    expect(panels.length).toBe(2);
+  });
+
+  it('should build usage chart data from inputs', () => {
+    hostComponent.dailyUsage = [
+      { date: '2026-02-08', count: 5 },
+      { date: '2026-02-09', count: 12 },
+    ];
+    hostComponent.dailyResponseTimes = [];
+    hostFixture.detectChanges();
+
+    const component = hostFixture.debugElement.children[0].componentInstance as UsageChartComponent;
+    const chartData = component.usageChartData();
+
+    expect(chartData.labels).toHaveLength(2);
+    expect(chartData.datasets[0].data).toEqual([5, 12]);
+    expect(chartData.datasets[0].label).toBe('Questions');
+  });
+
+  it('should build response time chart data from inputs', () => {
+    hostComponent.dailyUsage = [];
+    hostComponent.dailyResponseTimes = [
+      { date: '2026-02-08', averageMs: 1200 },
+      { date: '2026-02-09', averageMs: 980 },
+    ];
+    hostFixture.detectChanges();
+
+    const component = hostFixture.debugElement.children[0].componentInstance as UsageChartComponent;
+    const chartData = component.responseTimeChartData();
+
+    expect(chartData.labels).toHaveLength(2);
+    expect(chartData.datasets[0].data).toEqual([1.2, 0.98]);
+    expect(chartData.datasets[0].label).toBe('Avg Response Time (s)');
+  });
+
+  it('should handle empty chart data', () => {
+    hostComponent.dailyUsage = [];
+    hostComponent.dailyResponseTimes = [];
+    hostFixture.detectChanges();
+
+    const component = hostFixture.debugElement.children[0].componentInstance as UsageChartComponent;
+    const usageData = component.usageChartData();
+    const responseData = component.responseTimeChartData();
+
+    expect(usageData.labels).toHaveLength(0);
+    expect(usageData.datasets[0].data).toEqual([]);
+    expect(responseData.labels).toHaveLength(0);
+    expect(responseData.datasets[0].data).toEqual([]);
+  });
+
+  it('should convert response times from ms to seconds', () => {
+    hostComponent.dailyResponseTimes = [{ date: '2026-02-08', averageMs: 5000 }];
+    hostFixture.detectChanges();
+
+    const component = hostFixture.debugElement.children[0].componentInstance as UsageChartComponent;
+    const chartData = component.responseTimeChartData();
+    expect(chartData.datasets[0].data[0]).toBe(5);
+  });
+
+  it('should format dates for chart labels', () => {
+    hostComponent.dailyUsage = [{ date: '2026-02-08', count: 5 }];
+    hostFixture.detectChanges();
+
+    const component = hostFixture.debugElement.children[0].componentInstance as UsageChartComponent;
+    const chartData = component.usageChartData();
+    expect(chartData.labels[0]).toBe('08 Feb');
+  });
+});

--- a/frontend/src/app/features/analytics/components/usage-chart/usage-chart.component.ts
+++ b/frontend/src/app/features/analytics/components/usage-chart/usage-chart.component.ts
@@ -1,0 +1,142 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChartModule } from 'primeng/chart';
+import { DailyCount, DailyAverage } from '../../../../core/models';
+
+@Component({
+  selector: 'app-usage-chart',
+  imports: [ChartModule],
+  templateUrl: './usage-chart.component.html',
+  styleUrl: './usage-chart.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UsageChartComponent {
+  dailyUsage = input.required<DailyCount[]>();
+  dailyResponseTimes = input.required<DailyAverage[]>();
+
+  usageChartData = computed(() => {
+    const usage = this.dailyUsage();
+    return {
+      labels: usage.map((d) => this.formatDate(d.date)),
+      datasets: [
+        {
+          label: 'Questions',
+          data: usage.map((d) => d.count),
+          backgroundColor: 'rgba(34, 211, 238, 0.6)',
+          borderColor: '#22d3ee',
+          borderWidth: 1,
+          borderRadius: 4,
+        },
+      ],
+    };
+  });
+
+  usageChartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        labels: {
+          color: '#9199b0',
+          font: { family: "'Plus Jakarta Sans', system-ui, sans-serif", size: 12 },
+        },
+      },
+    },
+    scales: {
+      x: {
+        ticks: {
+          color: '#6b7494',
+          font: { size: 11 },
+        },
+        grid: {
+          color: 'rgba(255, 255, 255, 0.04)',
+        },
+      },
+      y: {
+        beginAtZero: true,
+        ticks: {
+          color: '#6b7494',
+          font: { size: 11 },
+          stepSize: 1,
+        },
+        grid: {
+          color: 'rgba(255, 255, 255, 0.04)',
+        },
+      },
+    },
+  };
+
+  responseTimeChartData = computed(() => {
+    const times = this.dailyResponseTimes();
+    return {
+      labels: times.map((d) => this.formatDate(d.date)),
+      datasets: [
+        {
+          label: 'Avg Response Time (s)',
+          data: times.map((d) => d.averageMs / 1000),
+          borderColor: '#fbbf24',
+          backgroundColor: 'rgba(251, 191, 36, 0.1)',
+          tension: 0.3,
+          fill: true,
+          pointBackgroundColor: '#fbbf24',
+          pointBorderColor: '#fbbf24',
+          pointRadius: 3,
+        },
+      ],
+    };
+  });
+
+  responseTimeChartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        labels: {
+          color: '#9199b0',
+          font: { family: "'Plus Jakarta Sans', system-ui, sans-serif", size: 12 },
+        },
+      },
+    },
+    scales: {
+      x: {
+        ticks: {
+          color: '#6b7494',
+          font: { size: 11 },
+        },
+        grid: {
+          color: 'rgba(255, 255, 255, 0.04)',
+        },
+      },
+      y: {
+        beginAtZero: true,
+        ticks: {
+          color: '#6b7494',
+          font: { size: 11 },
+          callback: (value: number) => value + 's',
+        },
+        grid: {
+          color: 'rgba(255, 255, 255, 0.04)',
+        },
+      },
+    },
+  };
+
+  private formatDate(dateStr: string): string {
+    const date = new Date(dateStr);
+    const day = date.getDate().toString().padStart(2, '0');
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    return `${day} ${months[date.getMonth()]}`;
+  }
+}

--- a/frontend/src/app/layout/header/header.component.html
+++ b/frontend/src/app/layout/header/header.component.html
@@ -46,6 +46,16 @@
         </svg>
         <span>Documents</span>
       </a>
+      <a routerLink="/analytics" routerLinkActive="active" class="nav-link">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
+          <path
+            d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <span>Analytics</span>
+      </a>
     </nav>
   </div>
 </header>

--- a/frontend/src/app/layout/header/header.component.spec.ts
+++ b/frontend/src/app/layout/header/header.component.spec.ts
@@ -21,10 +21,11 @@ describe('HeaderComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should have menu items for Chat and Admin', () => {
-    expect(component.menuItems).toHaveLength(2);
+  it('should have menu items for Chat, Admin, and Analytics', () => {
+    expect(component.menuItems).toHaveLength(3);
     expect(component.menuItems[0].label).toBe('Chat');
     expect(component.menuItems[1].label).toBe('Admin');
+    expect(component.menuItems[2].label).toBe('Analytics');
   });
 
   it('should display brand title', () => {
@@ -36,7 +37,7 @@ describe('HeaderComponent', () => {
   it('should have navigation links', () => {
     const compiled = fixture.nativeElement;
     const navLinks = compiled.querySelectorAll('.nav-link');
-    expect(navLinks.length).toBe(2);
+    expect(navLinks.length).toBe(3);
   });
 
   it('should have Chat navigation link with correct route', () => {
@@ -62,7 +63,7 @@ describe('HeaderComponent', () => {
   it('should have navigation SVG icons', () => {
     const compiled = fixture.nativeElement;
     const icons = compiled.querySelectorAll('.nav-link svg');
-    expect(icons.length).toBe(2);
+    expect(icons.length).toBe(3);
   });
 
   it('should use routerLinkActive directive', () => {

--- a/frontend/src/app/layout/header/header.component.ts
+++ b/frontend/src/app/layout/header/header.component.ts
@@ -30,5 +30,11 @@ export class HeaderComponent {
       routerLink: '/admin',
       command: () => this.router.navigate(['/admin']),
     },
+    {
+      label: 'Analytics',
+      icon: 'pi pi-chart-bar',
+      routerLink: '/analytics',
+      command: () => this.router.navigate(['/analytics']),
+    },
   ];
 }

--- a/specs/004-analytics-dashboard/checklists/requirements.md
+++ b/specs/004-analytics-dashboard/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Analytics Dashboard
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation on first iteration.
+- Assumptions section documents key decisions: no auth system needed, response time measurement scope, rolling 30-day window.

--- a/specs/004-analytics-dashboard/contracts/analytics-api.yaml
+++ b/specs/004-analytics-dashboard/contracts/analytics-api.yaml
@@ -1,0 +1,149 @@
+openapi: 3.1.0
+info:
+  title: HR Assistant RAG - Analytics API
+  version: 1.0.0
+  description: Analytics endpoints for the HR Assistant RAG dashboard
+
+paths:
+  /api/analytics/dashboard:
+    get:
+      operationId: getDashboardAnalytics
+      summary: Get all dashboard analytics data
+      description: Returns aggregated analytics including KPIs, popular questions, top documents, and time-series data.
+      tags:
+        - Analytics
+      responses:
+        '200':
+          description: Dashboard analytics data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardAnalytics'
+        '500':
+          description: Internal server error
+
+components:
+  schemas:
+    DashboardAnalytics:
+      type: object
+      required:
+        - totalQuestionsToday
+        - averageResponseTimeMs
+        - totalDocuments
+        - conversationsThisWeek
+        - popularQuestions
+        - topDocuments
+        - dailyUsage
+        - dailyResponseTimes
+      properties:
+        totalQuestionsToday:
+          type: integer
+          format: int64
+          description: Count of chat interactions created today
+          example: 42
+        averageResponseTimeMs:
+          type: number
+          format: double
+          description: Average response time in milliseconds across all interactions
+          example: 1250.5
+        totalDocuments:
+          type: integer
+          format: int64
+          description: Total number of documents in the system
+          example: 15
+        conversationsThisWeek:
+          type: integer
+          format: int64
+          description: Count of chat interactions in the current week (Monday to Sunday)
+          example: 128
+        popularQuestions:
+          type: array
+          items:
+            $ref: '#/components/schemas/QuestionFrequency'
+          description: Top 10 most frequently asked questions
+        topDocuments:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocumentReference'
+          description: Top 10 most referenced documents in RAG responses
+        dailyUsage:
+          type: array
+          items:
+            $ref: '#/components/schemas/DailyCount'
+          description: Daily question counts for the last 30 days
+        dailyResponseTimes:
+          type: array
+          items:
+            $ref: '#/components/schemas/DailyAverage'
+          description: Daily average response times for the last 30 days
+
+    QuestionFrequency:
+      type: object
+      required:
+        - question
+        - count
+      properties:
+        question:
+          type: string
+          description: The question text
+          example: "Comment poser des jours de congé ?"
+        count:
+          type: integer
+          format: int64
+          description: Number of times this question was asked
+          example: 15
+
+    DocumentReference:
+      type: object
+      required:
+        - documentId
+        - documentName
+        - referenceCount
+      properties:
+        documentId:
+          type: string
+          description: Document identifier
+          example: "d1a2b3c4-5678-9012-3456-789abcdef012"
+        documentName:
+          type: string
+          description: Document filename
+          example: "politique-conges-2025.pdf"
+        referenceCount:
+          type: integer
+          format: int64
+          description: Number of times referenced in RAG responses
+          example: 42
+
+    DailyCount:
+      type: object
+      required:
+        - date
+        - count
+      properties:
+        date:
+          type: string
+          format: date
+          description: The day
+          example: "2026-02-10"
+        count:
+          type: integer
+          format: int64
+          description: Number of interactions that day
+          example: 12
+
+    DailyAverage:
+      type: object
+      required:
+        - date
+        - averageMs
+      properties:
+        date:
+          type: string
+          format: date
+          description: The day
+          example: "2026-02-10"
+        averageMs:
+          type: number
+          format: double
+          description: Average response time in milliseconds
+          example: 1340.2

--- a/specs/004-analytics-dashboard/data-model.md
+++ b/specs/004-analytics-dashboard/data-model.md
@@ -1,0 +1,88 @@
+# Data Model: Analytics Dashboard
+
+**Feature**: 004-analytics-dashboard
+**Date**: 2026-02-10
+
+## New Entities
+
+### ChatInteraction
+
+Represents a completed Q&A exchange. Persisted to PostgreSQL for analytics aggregation.
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| id | String (UUID) | PK, auto-generated | Unique interaction identifier |
+| question | String | NOT NULL, max 1000 chars | The user's question text |
+| responseTimeMs | Long | NOT NULL | Time from request to stream completion (milliseconds) |
+| referencedDocumentIds | List\<String\> | nullable | IDs of documents used in RAG response |
+| createdAt | LocalDateTime | NOT NULL, indexed | Timestamp of the interaction |
+
+**Table name**: `chat_interactions`
+
+**Indexes**:
+- `idx_chat_interactions_created_at` on `createdAt` (for time-range queries)
+- `idx_chat_interactions_question` on `LOWER(question)` (for frequency grouping)
+
+**Relationships**:
+- `referencedDocumentIds` → references `Document.id` (soft reference, no FK constraint — documents may be deleted)
+
+**Storage**: JPA `@ElementCollection` for `referencedDocumentIds` stored in a join table `chat_interaction_documents`.
+
+## Existing Entities (unchanged)
+
+### Document
+
+No schema changes. Referenced by `ChatInteraction.referencedDocumentIds` via soft reference.
+
+## Analytics DTOs (not persisted)
+
+### DashboardAnalytics
+
+Aggregated response DTO returned by the analytics endpoint.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| totalQuestionsToday | Long | Count of interactions created today |
+| averageResponseTimeMs | Double | Average response time across all interactions |
+| totalDocuments | Long | Count of documents in the system |
+| conversationsThisWeek | Long | Count of interactions in the current week (Mon-Sun) |
+| popularQuestions | List\<QuestionFrequency\> | Top 10 questions by frequency |
+| topDocuments | List\<DocumentReference\> | Top 10 documents by reference count |
+| dailyUsage | List\<DailyCount\> | Daily question counts for last 30 days |
+| dailyResponseTimes | List\<DailyAverage\> | Daily average response times for last 30 days |
+
+### QuestionFrequency
+
+| Field | Type | Description |
+|-------|------|-------------|
+| question | String | The question text |
+| count | Long | Number of times asked |
+
+### DocumentReference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| documentId | String | Document identifier |
+| documentName | String | Document filename |
+| referenceCount | Long | Number of times referenced in RAG responses |
+
+### DailyCount
+
+| Field | Type | Description |
+|-------|------|-------------|
+| date | LocalDate | The day |
+| count | Long | Number of interactions that day |
+
+### DailyAverage
+
+| Field | Type | Description |
+|-------|------|-------------|
+| date | LocalDate | The day |
+| averageMs | Double | Average response time in milliseconds |
+
+## Database Migration
+
+No Flyway/Liquibase in use — schema managed by `hibernate.ddl-auto: update`. JPA entity annotations will auto-create:
+- `chat_interactions` table
+- `chat_interaction_documents` join table
+- Required indexes via `@Table(indexes = ...)`

--- a/specs/004-analytics-dashboard/plan.md
+++ b/specs/004-analytics-dashboard/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Analytics Dashboard
+
+**Branch**: `004-analytics-dashboard` | **Date**: 2026-02-10 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/004-analytics-dashboard/spec.md`
+
+## Summary
+
+Add an analytics dashboard to the HR Assistant RAG application. The backend will persist chat interactions (question, response time, referenced documents) in PostgreSQL via a new `ChatInteraction` JPA entity, and expose REST endpoints for aggregated analytics. The frontend will display a dashboard page with KPI cards, ranked lists (popular questions, top documents), and time-series charts (daily usage, response times) using PrimeNG Chart components backed by Chart.js.
+
+## Technical Context
+
+**Language/Version**: Java 21 (Corretto) + TypeScript 5.9
+**Primary Dependencies**: Spring Boot 4.0.1, Spring AI 2.0.0-M1, Spring Data JPA, Angular 21, PrimeNG v21, Chart.js 4.x
+**Storage**: PostgreSQL 16 + pgvector (existing), new `chat_interactions` table
+**Testing**: JUnit 5 + Mockito (backend), Vitest (frontend)
+**Target Platform**: Web (macOS dev, Linux prod)
+**Project Type**: Web application (backend + frontend)
+**Performance Goals**: Dashboard KPIs load within 2 seconds, server-side aggregation for all analytics queries
+**Constraints**: No additional infrastructure (reuse existing PostgreSQL), minimal impact on chat response latency
+**Scale/Scope**: Single new page, ~5 new backend files, ~8 new frontend files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Library-First | PASS | Using PrimeNG Chart (Chart.js wrapper), Spring Data JPA for aggregation queries, no custom implementations |
+| II. English-Only Code Artifacts | PASS | All code, comments, and docs in English |
+| III. Incremental Validation | PASS | User stories are prioritized P1→P3, each independently testable |
+| IV. Artifact Synchronization | PASS | Will maintain tasks.md sync during implementation |
+| V. Lean Configuration | PASS | Only adding `chart.js` dependency, no new infrastructure |
+
+No violations. All principles satisfied.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-analytics-dashboard/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+backend/
+├── src/main/java/com/hrassistant/
+│   ├── model/
+│   │   └── ChatInteraction.java           # New JPA entity
+│   ├── repository/
+│   │   └── ChatInteractionRepository.java # New repository with aggregation queries
+│   ├── service/
+│   │   ├── AnalyticsService.java          # New analytics aggregation service
+│   │   └── StreamingRagService.java       # Modified: persist interaction after completion
+│   └── controller/
+│       └── AnalyticsController.java       # New REST controller
+└── src/test/java/com/hrassistant/
+    ├── service/
+    │   └── AnalyticsServiceTest.java      # New unit tests
+    └── controller/
+        └── AnalyticsControllerTest.java   # New controller tests
+
+frontend/
+├── src/app/
+│   ├── features/analytics/
+│   │   └── components/
+│   │       ├── analytics-page/            # Container component (lazy-loaded)
+│   │       ├── kpi-cards/                 # KPI summary cards
+│   │       ├── popular-questions/         # Top 10 questions list
+│   │       ├── top-documents/             # Top 10 documents list
+│   │       └── usage-chart/              # Time-series charts (usage + response time)
+│   ├── core/services/
+│   │   └── analytics.service.ts           # New analytics API service
+│   ├── core/models/
+│   │   └── analytics.model.ts             # New analytics DTOs
+│   ├── app.routes.ts                      # Modified: add /analytics route
+│   └── layout/header/
+│       └── header.component.html          # Modified: add Analytics nav link
+└── src/app/features/analytics/
+    └── components/*/
+        └── *.spec.ts                      # Component tests
+```
+
+**Structure Decision**: Follows existing web application structure. Analytics feature module mirrors the admin feature pattern (container + presentational components). Backend follows the existing layered architecture (controller → service → repository).

--- a/specs/004-analytics-dashboard/quickstart.md
+++ b/specs/004-analytics-dashboard/quickstart.md
@@ -1,0 +1,75 @@
+# Quickstart: Analytics Dashboard
+
+**Feature**: 004-analytics-dashboard
+**Date**: 2026-02-10
+
+## Prerequisites
+
+- Docker Compose running (PostgreSQL + Redis): `cd backend && docker compose up -d`
+- Ollama running with models: `ollama serve` (llama3.2 + nomic-embed-text)
+- Backend running: `cd backend && mvn spring-boot:run`
+- Frontend running: `cd frontend && npm start`
+
+## New Dependency
+
+Install Chart.js for PrimeNG charts:
+
+```bash
+cd frontend && npm install chart.js
+```
+
+## Implementation Order
+
+### Phase 1: Backend Data Layer (P1 - KPIs)
+1. Create `ChatInteraction` JPA entity with `@Entity`, `@Table`, `@ElementCollection`
+2. Create `ChatInteractionRepository` with aggregation `@Query` methods
+3. Modify `CachingStreamingRagService` to persist interactions after stream completion
+4. Create analytics DTO records: `DashboardAnalytics`, `QuestionFrequency`, `DocumentReference`, `DailyCount`, `DailyAverage`
+5. Create `AnalyticsService` that calls repository methods and assembles `DashboardAnalytics`
+6. Create `AnalyticsController` with `GET /api/analytics/dashboard`
+
+### Phase 2: Frontend Dashboard (P1 - KPIs)
+7. Create `analytics.model.ts` with TypeScript interfaces matching backend DTOs
+8. Create `analytics.service.ts` with `getDashboardAnalytics$()` method
+9. Create `analytics-page` container component (lazy-loaded)
+10. Create `kpi-cards` component displaying 4 KPI cards
+11. Add route `/analytics` in `app.routes.ts`
+12. Add "Analytics" nav link in header
+
+### Phase 3: Lists (P2)
+13. Create `popular-questions` component (ranked list with truncation)
+14. Create `top-documents` component (ranked list with reference counts)
+
+### Phase 4: Charts (P3)
+15. Create `usage-chart` component with daily usage line chart
+16. Add response time trend chart to `usage-chart` component
+
+### Phase 5: Tests
+17. Backend unit tests: `AnalyticsServiceTest`, `AnalyticsControllerTest`
+18. Frontend component tests: all analytics components
+
+## Verification
+
+```bash
+# Backend compiles
+cd backend && mvn clean compile
+
+# Backend tests pass
+cd backend && mvn test
+
+# Frontend compiles
+cd frontend && ng build
+
+# Frontend tests pass
+cd frontend && ng test
+
+# Manual: navigate to http://localhost:4200/analytics
+# Verify KPI cards, popular questions, top documents, charts
+```
+
+## API Test
+
+```bash
+# After some chat interactions exist:
+curl http://localhost:8080/api/analytics/dashboard | jq .
+```

--- a/specs/004-analytics-dashboard/research.md
+++ b/specs/004-analytics-dashboard/research.md
@@ -1,0 +1,77 @@
+# Research: Analytics Dashboard
+
+**Feature**: 004-analytics-dashboard
+**Date**: 2026-02-10
+
+## R1: Chat Interaction Persistence Strategy
+
+**Decision**: Use a new JPA entity `ChatInteraction` persisted to PostgreSQL via Spring Data JPA.
+
+**Rationale**: The application already uses PostgreSQL with Spring Data JPA for `Document` entities. Adding a new table is the simplest approach with zero new infrastructure. JPA aggregation queries (`@Query` with `GROUP BY`, `COUNT`, `AVG`) handle all analytics needs server-side.
+
+**Alternatives considered**:
+- **Application logs + log parser**: Would require log parsing infrastructure, not real-time queryable, brittle to log format changes. Rejected.
+- **Micrometer + Prometheus**: Overkill for this scope — adds two new infrastructure dependencies (Prometheus + Grafana) for 5 metrics. Rejected.
+- **Redis time-series**: Would add another Redis data structure. PostgreSQL is already available and better suited for complex aggregation queries. Rejected.
+
+## R2: When to Record Interactions
+
+**Decision**: Record interaction asynchronously after the SSE stream completes in `StreamingRagService` (or `CachingStreamingRagService`).
+
+**Rationale**: Recording must happen after the full response is assembled (to capture response time and referenced documents). Using `doOnComplete` on the Flux ensures zero impact on streaming latency. The interaction is saved asynchronously on `Schedulers.boundedElastic()`.
+
+**Alternatives considered**:
+- **Synchronous save before response**: Would add latency to chat response. Rejected.
+- **Save in controller layer**: Controller doesn't have access to response time or referenced documents. Rejected.
+- **Event-driven (Spring Events)**: Adds unnecessary indirection for a single subscriber. Rejected.
+
+## R3: Question Similarity for "Popular Questions"
+
+**Decision**: Use exact string matching (case-insensitive) with `LOWER(question)` GROUP BY for question frequency counting.
+
+**Rationale**: Simple, performant with a database index, and sufficient for identifying repeated questions. Semantic similarity would require embedding comparison which is expensive and unnecessary for a "top 10" list.
+
+**Alternatives considered**:
+- **Embedding-based clustering**: Too expensive for a dashboard query that runs on every page load. Would need pre-computed clusters. Rejected for V1.
+- **Fuzzy matching (Levenshtein)**: Complex query, harder to index, marginal benefit over exact match. Rejected for V1.
+
+## R4: Frontend Charting Library
+
+**Decision**: Use Chart.js 4.x via PrimeNG's `p-chart` component.
+
+**Rationale**: PrimeNG already wraps Chart.js with its `ChartModule`. This is the library-first approach per Constitution Principle I. Only requires adding `chart.js` as a dependency — no additional charting library.
+
+**Alternatives considered**:
+- **Apache ECharts**: More powerful but adds a large dependency (800KB+) and doesn't integrate with PrimeNG. Rejected.
+- **D3.js**: Low-level, requires significant custom code. Violates library-first principle. Rejected.
+- **ng2-charts**: Another Chart.js wrapper, but PrimeNG already provides one. Adding a second wrapper is redundant. Rejected.
+
+## R5: Document Reference Tracking
+
+**Decision**: Extract document IDs from the vector search results in `StreamingRagService.extractSources()` and include them in the `ChatInteraction` record.
+
+**Rationale**: The existing `extractSources()` method already identifies which documents were used in the RAG response. We piggyback on this data to populate the `referencedDocumentIds` field.
+
+**Alternatives considered**:
+- **Parse source references from response text**: Fragile, depends on response format. Rejected.
+- **Separate document tracking service**: Over-engineering for storing a list of IDs. Rejected.
+
+## R6: Analytics Endpoint Design
+
+**Decision**: Single endpoint `GET /api/analytics/dashboard` returning all dashboard data in one response.
+
+**Rationale**: The dashboard loads all sections simultaneously. A single endpoint reduces HTTP overhead and simplifies frontend logic. Server-side aggregation is fast enough (simple SQL queries on indexed columns) to return all data within the 2-second target.
+
+**Alternatives considered**:
+- **Multiple endpoints per section**: More HTTP calls, more complex loading states, no real benefit since all data is needed simultaneously. Rejected for V1.
+- **GraphQL**: Adds a new paradigm to the project for one endpoint. Overkill. Rejected.
+
+## R7: Response Time Measurement
+
+**Decision**: Measure wall-clock time from request receipt to stream completion using `System.currentTimeMillis()` diff.
+
+**Rationale**: Simple, accurate for user-perceived latency, consistent with the existing `LoggingInterceptor` approach.
+
+**Alternatives considered**:
+- **Micrometer Timer**: Adds a dependency for one measurement. Rejected.
+- **Reactive elapsed operator**: `Flux.elapsed()` measures inter-element time, not total time. Not suitable. Rejected.

--- a/specs/004-analytics-dashboard/spec.md
+++ b/specs/004-analytics-dashboard/spec.md
@@ -1,0 +1,135 @@
+# Feature Specification: Analytics Dashboard
+
+**Feature Branch**: `004-analytics-dashboard`
+**Created**: 2026-02-10
+**Status**: Draft
+**Input**: User description: "Analytics Dashboard for the HR Assistant RAG application. Dashboard with stats: popular questions asked by users, average response times, most consulted/referenced documents, daily/weekly usage metrics. Admin-only page accessible from the header navigation. Backend endpoints to aggregate and serve analytics data from existing chat and document interactions. Frontend dashboard with charts and KPIs using PrimeNG components."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View Key Performance Indicators (Priority: P1)
+
+An administrator navigates to the Analytics page from the header navigation. They see a dashboard with KPI cards showing at-a-glance metrics: total questions asked today, average response time, total documents in the system, and total conversations this week. The data refreshes each time the page is loaded.
+
+**Why this priority**: KPIs provide the highest-value overview with the least complexity. Even without charts, administrators gain immediate insight into system health and usage.
+
+**Independent Test**: Can be fully tested by navigating to the Analytics page and verifying that KPI cards display correct aggregated numbers matching the underlying data.
+
+**Acceptance Scenarios**:
+
+1. **Given** the admin is on the app and has existing chat interactions, **When** they navigate to the Analytics page, **Then** they see KPI cards with total questions today, average response time, total documents, and conversations this week.
+2. **Given** no chat interactions have occurred yet, **When** the admin navigates to the Analytics page, **Then** KPI cards display zero values gracefully (no errors or broken UI).
+3. **Given** the admin is on the Analytics page, **When** they reload the page, **Then** the KPI values refresh with the latest data.
+
+---
+
+### User Story 2 - View Popular Questions (Priority: P2)
+
+An administrator wants to understand what employees are asking most frequently. On the Analytics page, they see a ranked list of the most popular questions (top 10), showing the question text and how many times it was asked. This helps HR identify common concerns and knowledge gaps.
+
+**Why this priority**: Understanding what users ask is the core analytical insight for an HR assistant. It directly informs document improvements and HR strategy.
+
+**Independent Test**: Can be tested by creating several chat interactions with repeated questions and verifying the popular questions list reflects correct ranking and counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** multiple users have asked similar questions, **When** the admin views the popular questions section, **Then** questions are ranked by frequency with the most-asked question first.
+2. **Given** fewer than 10 unique questions exist, **When** the admin views the section, **Then** only the available questions are shown without empty slots.
+3. **Given** no questions have been asked, **When** the admin views the section, **Then** an empty state message is displayed.
+
+---
+
+### User Story 3 - View Most Referenced Documents (Priority: P2)
+
+An administrator wants to know which uploaded documents are most frequently used in RAG responses. The Analytics page shows a ranked list of the top 10 most referenced documents, including the document name and reference count. This helps identify which documents are most valuable and which may need updating.
+
+**Why this priority**: Equal to popular questions in value — understanding document usage helps HR maintain and prioritize their knowledge base.
+
+**Independent Test**: Can be tested by performing chat interactions that reference different documents and verifying the document ranking matches actual reference counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** chat interactions have referenced various documents, **When** the admin views the most referenced documents section, **Then** documents are ranked by reference count, highest first.
+2. **Given** a document has been deleted but was previously referenced, **When** the admin views the section, **Then** the deleted document is excluded from the list.
+3. **Given** no documents have been referenced, **When** the admin views the section, **Then** an empty state message is displayed.
+
+---
+
+### User Story 4 - View Usage Over Time Chart (Priority: P3)
+
+An administrator wants to see usage trends. The Analytics page includes a chart showing the number of questions asked per day over the last 30 days. This helps identify patterns, peak usage days, and overall adoption trends.
+
+**Why this priority**: Time-series visualization adds deeper insight but depends on having the data aggregation infrastructure from P1/P2 stories in place.
+
+**Independent Test**: Can be tested by generating chat interactions across multiple days and verifying the chart accurately reflects daily counts.
+
+**Acceptance Scenarios**:
+
+1. **Given** chat interactions spanning multiple days, **When** the admin views the usage chart, **Then** a chart displays daily question counts for the last 30 days.
+2. **Given** days with no activity within the 30-day range, **When** the admin views the chart, **Then** those days show zero values (no gaps in the timeline).
+3. **Given** the system has been running for fewer than 30 days, **When** the admin views the chart, **Then** only the available days are shown.
+
+---
+
+### User Story 5 - View Average Response Time Trend (Priority: P3)
+
+An administrator wants to monitor system performance over time. The Analytics page shows a chart of average response times per day for the last 30 days, helping detect performance degradation or improvement.
+
+**Why this priority**: Performance monitoring is valuable but secondary to understanding what users ask and which documents are used.
+
+**Independent Test**: Can be tested by checking that the chart shows daily averages matching computed response times from chat logs.
+
+**Acceptance Scenarios**:
+
+1. **Given** chat interactions with varying response times, **When** the admin views the response time chart, **Then** a chart displays daily average response times for the last 30 days.
+2. **Given** a day with a single very slow response, **When** the admin views the chart, **Then** that day's average accurately reflects the outlier.
+
+---
+
+### Edge Cases
+
+- What happens when the analytics page is loaded while a chat interaction is actively streaming? Analytics should use only completed interactions.
+- How does the system handle extremely long questions when displaying popular questions? Questions should be truncated in the display with full text available on hover or click.
+- What happens when the dataset is very large (thousands of interactions)? Aggregation should be performed server-side, not client-side, to maintain performance.
+- What happens if the analytics endpoint is slow? The dashboard should show loading indicators per section, not block the entire page.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST record each completed chat interaction including the question text, response time, timestamp, and referenced document identifiers.
+- **FR-002**: System MUST provide an aggregated count of total questions for the current day.
+- **FR-003**: System MUST calculate the average response time across all completed interactions.
+- **FR-004**: System MUST rank questions by frequency and return the top 10 most asked questions.
+- **FR-005**: System MUST rank documents by reference count and return the top 10 most referenced documents.
+- **FR-006**: System MUST aggregate daily question counts for the last 30 days.
+- **FR-007**: System MUST aggregate daily average response times for the last 30 days.
+- **FR-008**: System MUST expose analytics data through dedicated endpoints.
+- **FR-009**: System MUST display analytics on a dedicated page accessible from the main navigation.
+- **FR-010**: System MUST show loading states while analytics data is being fetched.
+- **FR-011**: System MUST display meaningful empty states when no data is available for a section.
+- **FR-012**: System MUST truncate long question text in the popular questions list with the ability to see the full text.
+
+### Key Entities
+
+- **ChatInteraction**: Represents a completed Q&A exchange. Key attributes: question text, response time (milliseconds), timestamp, list of referenced document identifiers.
+- **AnalyticsSnapshot**: Aggregated analytics data for the dashboard. Key attributes: total questions today, average response time, total documents, conversations this week, popular questions list, top documents list, daily usage series, daily response time series.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Administrators can view all dashboard KPIs within 2 seconds of navigating to the Analytics page.
+- **SC-002**: Popular questions list accurately reflects the top 10 most frequently asked questions with correct counts.
+- **SC-003**: Most referenced documents list accurately reflects document usage based on actual RAG responses.
+- **SC-004**: Usage trend charts display 30 days of historical data with daily granularity.
+- **SC-005**: Dashboard sections load independently, allowing partial display while slower sections are still loading.
+- **SC-006**: The analytics page is accessible from the main header navigation.
+
+## Assumptions
+
+- The application currently does not persist chat interactions. A new persistence mechanism will be needed to record interactions for analytics.
+- "Administrator" access is determined by the existing navigation structure (the admin/documents page is already accessible). No separate authentication system is required for this feature.
+- Response time is measured from when the user sends a question to when the complete response is delivered (end of SSE stream).
+- Document reference tracking will leverage the existing RAG pipeline's document retrieval step.
+- The 30-day window for time-series data is a rolling window based on the current date.

--- a/specs/004-analytics-dashboard/tasks.md
+++ b/specs/004-analytics-dashboard/tasks.md
@@ -1,0 +1,236 @@
+# Tasks: Analytics Dashboard
+
+**Input**: Design documents from `/specs/004-analytics-dashboard/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/analytics-api.yaml, quickstart.md
+**Branch**: `004-analytics-dashboard`
+
+**Tech Stack**: Java 21 + Spring Boot 4.0.1 + Spring Data JPA | Angular 21 + PrimeNG v21 + Chart.js 4.x | PostgreSQL 16
+
+**Organization**: Tasks grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Install dependencies and prepare project structure
+
+- [ ] T001 Install Chart.js dependency in `frontend/package.json` via `cd frontend && npm install chart.js`
+- [ ] T002 Create analytics feature directory structure: `frontend/src/app/features/analytics/components/`
+
+**Checkpoint**: Dependencies installed, directory structure ready
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Data persistence layer that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 Create `ChatInteraction` JPA entity in `backend/src/main/java/com/hrassistant/model/ChatInteraction.java` with fields: id (UUID), question (String, max 1000), responseTimeMs (Long), referencedDocumentIds (ElementCollection), createdAt (LocalDateTime). Include `@Table` with indexes on `createdAt` and `LOWER(question)`
+- [ ] T004 Create `ChatInteractionRepository` in `backend/src/main/java/com/hrassistant/repository/ChatInteractionRepository.java` extending `JpaRepository<ChatInteraction, String>` with `@Query` methods: `countByCreatedAtAfter()`, `findAverageResponseTimeMs()`, `countByCreatedAtBetween()`, `findTopQuestionsByFrequency()`, `countDailyInteractions()`, `findDailyAverageResponseTimes()`
+- [ ] T005 Create analytics DTO records in `backend/src/main/java/com/hrassistant/model/analytics/`: `DashboardAnalytics`, `QuestionFrequency`, `DocumentReference`, `DailyCount`, `DailyAverage` as Java records matching contracts/analytics-api.yaml schemas
+- [ ] T006 Modify `CachingStreamingRagService` in `backend/src/main/java/com/hrassistant/service/CachingStreamingRagService.java` to persist `ChatInteraction` asynchronously after stream completion using `doOnComplete` + `Schedulers.boundedElastic()`. Capture start time, collect referenced document IDs from sources, and save via `ChatInteractionRepository`
+- [ ] T007 Create `AnalyticsService` in `backend/src/main/java/com/hrassistant/service/AnalyticsService.java` that assembles `DashboardAnalytics` by calling `ChatInteractionRepository` aggregation queries and `DocumentRepository.count()`
+- [ ] T008 Create `AnalyticsController` in `backend/src/main/java/com/hrassistant/controller/AnalyticsController.java` with `GET /api/analytics/dashboard` returning `ResponseEntity<DashboardAnalytics>` via `AnalyticsService`
+- [ ] T009 [P] Create `analytics.model.ts` in `frontend/src/app/core/models/analytics.model.ts` with TypeScript interfaces: `DashboardAnalytics`, `QuestionFrequency`, `DocumentReference`, `DailyCount`, `DailyAverage` matching backend DTOs
+- [ ] T010 [P] Create `AnalyticsService` in `frontend/src/app/core/services/analytics.service.ts` with `getDashboardAnalytics$(): Observable<DashboardAnalytics>` calling `GET /api/analytics/dashboard`. Export from `frontend/src/app/core/services/index.ts`
+
+**Checkpoint**: Backend persists interactions, exposes analytics endpoint. Frontend service ready to consume data.
+
+---
+
+## Phase 3: User Story 1 - View Key Performance Indicators (Priority: P1) MVP
+
+**Goal**: Admin navigates to Analytics page and sees 4 KPI cards: total questions today, average response time, total documents, conversations this week.
+
+**Independent Test**: Navigate to `/analytics`, verify KPI cards show correct aggregated numbers. With no data, cards show zeros gracefully.
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Create `analytics-page` container component in `frontend/src/app/features/analytics/components/analytics-page/` (analytics-page.component.ts, .html, .css). Standalone, OnPush, injects `AnalyticsService`, loads dashboard data in `ngOnInit()`, stores result in signal. Shows loading spinner while fetching
+- [ ] T012 [US1] Create `kpi-cards` component in `frontend/src/app/features/analytics/components/kpi-cards/` (kpi-cards.component.ts, .html, .css). Standalone, OnPush. Inputs: `totalQuestionsToday`, `averageResponseTimeMs`, `totalDocuments`, `conversationsThisWeek` via `input()`. Displays 4 styled cards with icons and formatted values (ms → seconds for response time)
+- [ ] T013 [US1] Add lazy-loaded route `/analytics` in `frontend/src/app/app.routes.ts` loading `AnalyticsPageComponent`
+- [ ] T014 [US1] Add "Analytics" nav link with chart SVG icon in `frontend/src/app/layout/header/header.component.html` following existing nav link pattern (routerLink, routerLinkActive, SVG icon)
+
+**Checkpoint**: User Story 1 fully functional — admin can navigate to /analytics and see 4 KPI cards with live data
+
+---
+
+## Phase 4: User Story 2 - View Popular Questions (Priority: P2)
+
+**Goal**: Admin sees a ranked list of the top 10 most asked questions with frequency counts.
+
+**Independent Test**: Create repeated chat interactions with same questions, verify popular questions list shows correct ranking and counts. Empty state when no data.
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] Create `popular-questions` component in `frontend/src/app/features/analytics/components/popular-questions/` (popular-questions.component.ts, .html, .css). Standalone, OnPush. Input: `questions` via `input<QuestionFrequency[]>()`. Displays ranked list with question text (truncated at 100 chars with tooltip for full text) and count badge. Empty state message when list is empty
+- [ ] T016 [US2] Integrate `popular-questions` component into `analytics-page.component.html`, passing `popularQuestions` data from dashboard analytics signal
+
+**Checkpoint**: User Stories 1 AND 2 functional — KPI cards + popular questions list
+
+---
+
+## Phase 5: User Story 3 - View Most Referenced Documents (Priority: P2)
+
+**Goal**: Admin sees a ranked list of the top 10 most referenced documents with reference counts.
+
+**Independent Test**: Perform chat interactions referencing different documents, verify document list shows correct ranking. Deleted documents excluded.
+
+### Implementation for User Story 3
+
+- [ ] T017 [US3] Add `findTopReferencedDocuments()` query to `ChatInteractionRepository` in `backend/src/main/java/com/hrassistant/repository/ChatInteractionRepository.java`. Join with `chat_interaction_documents` table, group by document ID, count references, join with `documents` table for filename, return top 10. Exclude deleted documents (only return IDs that exist in `documents` table)
+- [ ] T018 [US3] Update `AnalyticsService` in `backend/src/main/java/com/hrassistant/service/AnalyticsService.java` to populate `topDocuments` field using the new repository query
+- [ ] T019 [US3] Create `top-documents` component in `frontend/src/app/features/analytics/components/top-documents/` (top-documents.component.ts, .html, .css). Standalone, OnPush. Input: `documents` via `input<DocumentReference[]>()`. Displays ranked list with document name and reference count badge. Empty state message when list is empty
+- [ ] T020 [US3] Integrate `top-documents` component into `analytics-page.component.html`, passing `topDocuments` data from dashboard analytics signal
+
+**Checkpoint**: User Stories 1, 2, AND 3 functional — KPI cards + popular questions + top documents
+
+---
+
+## Phase 6: User Story 4 - View Usage Over Time Chart (Priority: P3)
+
+**Goal**: Admin sees a line/bar chart showing daily question counts for the last 30 days.
+
+**Independent Test**: Generate interactions across multiple days, verify chart shows correct daily counts with zero-fill for inactive days.
+
+### Implementation for User Story 4
+
+- [ ] T021 [US4] Create `usage-chart` component in `frontend/src/app/features/analytics/components/usage-chart/` (usage-chart.component.ts, .html, .css). Standalone, OnPush. Inputs: `dailyUsage` via `input<DailyCount[]>()`, `dailyResponseTimes` via `input<DailyAverage[]>()`. Use PrimeNG `p-chart` (bar chart) for daily usage. Format dates as "DD MMM" labels. Apply Midnight Studio theme colors (cyan/teal accents)
+- [ ] T022 [US4] Integrate `usage-chart` component into `analytics-page.component.html`, passing `dailyUsage` data from dashboard analytics signal
+
+**Checkpoint**: User Stories 1-4 functional — KPI cards + lists + usage chart
+
+---
+
+## Phase 7: User Story 5 - View Average Response Time Trend (Priority: P3)
+
+**Goal**: Admin sees a line chart showing daily average response times for the last 30 days.
+
+**Independent Test**: Verify chart shows daily averages matching computed response times from interactions.
+
+### Implementation for User Story 5
+
+- [ ] T023 [US5] Add response time line chart to `usage-chart` component in `frontend/src/app/features/analytics/components/usage-chart/usage-chart.component.ts`. Add a second `p-chart` (line chart) for `dailyResponseTimes` input. Format Y-axis as seconds, X-axis as "DD MMM". Use amber/warm accent color to differentiate from usage chart
+- [ ] T024 [US5] Integrate response time chart into `analytics-page.component.html`, passing `dailyResponseTimes` data from dashboard analytics signal
+
+**Checkpoint**: All user stories (1-5) fully functional
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Testing, quality, and edge case handling
+
+- [ ] T025 [P] Create `AnalyticsServiceTest` in `backend/src/test/java/com/hrassistant/service/AnalyticsServiceTest.java` with unit tests: verify KPI aggregation, popular questions ranking, top documents with deleted exclusion, daily counts with zero-fill, empty data handling
+- [ ] T026 [P] Create `AnalyticsControllerTest` in `backend/src/test/java/com/hrassistant/controller/AnalyticsControllerTest.java` with MockMvc test for `GET /api/analytics/dashboard` returning 200 with correct JSON structure
+- [ ] T027 [P] Create component tests for `analytics-page`, `kpi-cards`, `popular-questions`, `top-documents`, `usage-chart` in their respective `.spec.ts` files. Test loading states, empty states, data rendering, and input bindings
+- [ ] T028 Verify backend compiles and all tests pass: `cd backend && mvn clean test`
+- [ ] T029 Verify frontend compiles and all tests pass: `cd frontend && ng build && ng test`
+- [ ] T030 Run quickstart.md validation: start all services, navigate to `/analytics`, verify full dashboard renders with live data
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **User Stories (Phase 3-7)**: All depend on Phase 2 completion
+  - US1 (P1): Can start immediately after Phase 2
+  - US2 (P2): Can start after Phase 2 (frontend-only, independent of US1)
+  - US3 (P2): Can start after Phase 2 (needs T017-T018 backend work, then frontend)
+  - US4 (P3): Can start after Phase 2 (frontend-only)
+  - US5 (P3): Depends on US4 (extends same component)
+- **Polish (Phase 8)**: Depends on all user stories complete
+
+### Within Each User Story
+
+- Backend changes (repository queries, service methods) before frontend components
+- Container component before child components
+- Integration (wiring into page) as final step per story
+
+### Parallel Opportunities
+
+**Backend agents can work in parallel with frontend agents after Phase 2:**
+- T009 + T010 (frontend models/service) can run in parallel with T003-T008 (backend)
+- T011 + T012 (US1 frontend) can start once T008 (controller) is done
+- T015 (US2), T019 (US3), T021 (US4) are independent frontend components — all parallelizable
+- T025, T026, T027 (all test tasks) are parallelizable
+
+---
+
+## Parallel Example: Team of 3 Agents
+
+```text
+# Phase 2 — Backend agent:
+T003 → T004 → T005 → T006 → T007 → T008
+
+# Phase 2 — Frontend agent (in parallel):
+T009 + T010 (can start immediately, no backend dependency)
+
+# Phase 3-7 — After Phase 2 complete:
+Backend agent: T017 → T018 (US3 backend queries)
+Frontend agent: T011 → T012 → T013 → T014 (US1) → T015 → T016 (US2)
+Test agent: waits for implementation, then T025 + T026 + T027
+
+# Phase 6-7 — Frontend agent continues:
+T019 → T020 (US3 frontend) → T021 → T022 (US4) → T023 → T024 (US5)
+
+# Phase 8 — Test agent:
+T025 + T026 + T027 (parallel) → T028 → T029 → T030
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: Foundational (T003-T010)
+3. Complete Phase 3: User Story 1 (T011-T014)
+4. **STOP and VALIDATE**: Navigate to `/analytics`, verify KPI cards
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add User Story 1 → KPI cards working (MVP!)
+3. Add User Stories 2+3 → Popular questions + top documents
+4. Add User Stories 4+5 → Charts
+5. Polish → Tests + validation
+
+---
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total tasks | 30 |
+| Phase 1 (Setup) | 2 tasks |
+| Phase 2 (Foundational) | 8 tasks |
+| US1 (KPI Cards) | 4 tasks |
+| US2 (Popular Questions) | 2 tasks |
+| US3 (Top Documents) | 4 tasks |
+| US4 (Usage Chart) | 2 tasks |
+| US5 (Response Time Chart) | 2 tasks |
+| Phase 8 (Polish/Tests) | 6 tasks |
+| Parallel opportunities | T009+T010, T015+T019+T021, T025+T026+T027 |
+| MVP scope | Phase 1-3 (14 tasks) |
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently


### PR DESCRIPTION
## Summary
- Add analytics dashboard page with KPIs, popular questions, top documents, and usage charts
- Backend persists chat interactions and exposes `GET /api/analytics/dashboard` with aggregated data
- Frontend displays responsive dashboard with PrimeNG Chart.js components in Midnight Studio theme

## What's New

**Backend** (5 new files, 1 modified):
- `ChatInteraction` JPA entity persisted to PostgreSQL
- `ChatInteractionRepository` with aggregation queries (daily counts, top questions, top docs)
- `AnalyticsService` + `AnalyticsController` (`GET /api/analytics/dashboard`)
- `CachingStreamingRagService` modified to persist interactions async after stream completion

**Frontend** (12 new files, 3 modified):
- 5 standalone components: analytics-page, kpi-cards, popular-questions, top-documents, usage-chart
- `AnalyticsService` calling backend endpoint
- Lazy-loaded `/analytics` route + header nav link
- Bar chart (daily usage) + line chart (response times) via PrimeNG p-chart

**Spec artifacts**: spec.md, plan.md, research.md, data-model.md, contracts/, tasks.md

## Test plan
- [x] Backend: 82 tests passing (JUnit 5 + Mockito)
- [x] Frontend: 109 tests passing (Vitest)
- [x] `mvn clean test` — BUILD SUCCESS
- [x] `ng build && ng test` — SUCCESS
- [ ] Manual: navigate to `/analytics`, pose questions in chat, verify dashboard populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)