### PR TITLE
refactor: add @Builder to records with >2 properties

### DIFF
--- a/backend/src/main/java/com/hrassistant/model/ClassificationResponse.java
+++ b/backend/src/main/java/com/hrassistant/model/ClassificationResponse.java
@@ -1,5 +1,7 @@
 package com.hrassistant.model;
 
+import lombok.Builder;
+
 /**
  * Structure expected from the LLM classification response. Parsed via {@link
  * org.springframework.ai.converter.BeanOutputConverter}.
@@ -8,4 +10,5 @@ package com.hrassistant.model;
  * @param category category name (mapped to {@link HrCategory} enum)
  * @param confidence confidence level (mapped to {@link ConfidenceLevel} enum)
  */
+@Builder
 public record ClassificationResponse(boolean hrRelated, String category, String confidence) {}

--- a/backend/src/main/java/com/hrassistant/model/analytics/DashboardAnalytics.java
+++ b/backend/src/main/java/com/hrassistant/model/analytics/DashboardAnalytics.java
@@ -1,7 +1,9 @@
 package com.hrassistant.model.analytics;
 
 import java.util.List;
+import lombok.Builder;
 
+@Builder
 public record DashboardAnalytics(
     long totalQuestionsToday,
     double averageResponseTimeMs,

--- a/backend/src/main/java/com/hrassistant/model/analytics/DocumentReference.java
+++ b/backend/src/main/java/com/hrassistant/model/analytics/DocumentReference.java
@@ -1,3 +1,6 @@
 package com.hrassistant.model.analytics;
 
+import lombok.Builder;
+
+@Builder
 public record DocumentReference(String documentId, String documentName, long referenceCount) {}

--- a/backend/src/main/java/com/hrassistant/service/AnalyticsService.java
+++ b/backend/src/main/java/com/hrassistant/service/AnalyticsService.java
@@ -51,15 +51,16 @@ public class AnalyticsService {
         totalDocuments,
         conversationsThisWeek);
 
-    return new DashboardAnalytics(
-        totalQuestionsToday,
-        averageResponseTimeMs,
-        totalDocuments,
-        conversationsThisWeek,
-        popularQuestions,
-        topDocuments,
-        dailyUsage,
-        dailyResponseTimes);
+    return DashboardAnalytics.builder()
+        .totalQuestionsToday(totalQuestionsToday)
+        .averageResponseTimeMs(averageResponseTimeMs)
+        .totalDocuments(totalDocuments)
+        .conversationsThisWeek(conversationsThisWeek)
+        .popularQuestions(popularQuestions)
+        .topDocuments(topDocuments)
+        .dailyUsage(dailyUsage)
+        .dailyResponseTimes(dailyResponseTimes)
+        .build();
   }
 
   private List<QuestionFrequency> mapQuestionFrequencies(List<Object[]> rows) {
@@ -72,8 +73,11 @@ public class AnalyticsService {
     return rows.stream()
         .map(
             row ->
-                new DocumentReference(
-                    (String) row[0], (String) row[1], ((Number) row[2]).longValue()))
+                DocumentReference.builder()
+                    .documentId((String) row[0])
+                    .documentName((String) row[1])
+                    .referenceCount(((Number) row[2]).longValue())
+                    .build())
         .toList();
   }
 

--- a/backend/src/test/java/com/hrassistant/controller/AnalyticsControllerTest.java
+++ b/backend/src/test/java/com/hrassistant/controller/AnalyticsControllerTest.java
@@ -26,15 +26,22 @@ class AnalyticsControllerTest {
   @DisplayName("GET /api/analytics/dashboard returns 200 with correct data")
   void getDashboardReturns200WithCorrectData() {
     DashboardAnalytics analytics =
-        new DashboardAnalytics(
-            42L,
-            1500.0,
-            10L,
-            120L,
-            List.of(new QuestionFrequency("leave policy", 15)),
-            List.of(new DocumentReference("doc-1", "handbook.pdf", 25)),
-            List.of(new DailyCount(LocalDate.of(2026, 2, 8), 5)),
-            List.of(new DailyAverage(LocalDate.of(2026, 2, 8), 1200.5)));
+        DashboardAnalytics.builder()
+            .totalQuestionsToday(42L)
+            .averageResponseTimeMs(1500.0)
+            .totalDocuments(10L)
+            .conversationsThisWeek(120L)
+            .popularQuestions(List.of(new QuestionFrequency("leave policy", 15)))
+            .topDocuments(
+                List.of(
+                    DocumentReference.builder()
+                        .documentId("doc-1")
+                        .documentName("handbook.pdf")
+                        .referenceCount(25)
+                        .build()))
+            .dailyUsage(List.of(new DailyCount(LocalDate.of(2026, 2, 8), 5)))
+            .dailyResponseTimes(List.of(new DailyAverage(LocalDate.of(2026, 2, 8), 1200.5)))
+            .build();
 
     when(analyticsService.getDashboardAnalytics()).thenReturn(analytics);
 
@@ -60,7 +67,16 @@ class AnalyticsControllerTest {
   @DisplayName("GET /api/analytics/dashboard returns empty analytics when no data")
   void getDashboardReturnsEmptyAnalytics() {
     DashboardAnalytics emptyAnalytics =
-        new DashboardAnalytics(0L, 0.0, 0L, 0L, List.of(), List.of(), List.of(), List.of());
+        DashboardAnalytics.builder()
+            .totalQuestionsToday(0L)
+            .averageResponseTimeMs(0.0)
+            .totalDocuments(0L)
+            .conversationsThisWeek(0L)
+            .popularQuestions(List.of())
+            .topDocuments(List.of())
+            .dailyUsage(List.of())
+            .dailyResponseTimes(List.of())
+            .build();
 
     when(analyticsService.getDashboardAnalytics()).thenReturn(emptyAnalytics);
 


### PR DESCRIPTION
## Summary
- Added Lombok `@Builder` to `DashboardAnalytics`, `DocumentReference`, and `ClassificationResponse` records (>2 properties)
- Refactored call sites in `AnalyticsService` and `AnalyticsControllerTest` to use `.builder()...build()` pattern
- Skipped `GuardrailResult` and `OutputGuardrailResult` (compact constructors with validation logic incompatible with @Builder)

## Test plan
- [x] All 82 backend tests pass (BUILD SUCCESS)
- [x] No functional changes — builder pattern produces identical objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)